### PR TITLE
Added repository secrets to ROCm and pointing the workflow file to use them

### DIFF
--- a/.github/workflows/issue_retrieval.yml
+++ b/.github/workflows/issue_retrieval.yml
@@ -12,8 +12,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ vars.APP_ID }}
-          private_key: ${{ vars.APP_PEM }}
+          app_id: ${{ secrets.ACTION_APP_ID }}
+          private_key: ${{ secrets.ACTION_PEM }}
       - name: 'Retrieve Issue'
         uses: abhimeda/rocm_issue_management@main
         with:


### PR DESCRIPTION
Spoke with GitHub admin team as to why my GitHub action was still not running. They told me that the repo variables/secrets were not set and that I needed to that first. They granted me admin privileges for ROCm and I've added the necessary secrets to get the action to work. I modified the workflow file to point to it.