### PR TITLE
Fix link to building.md in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The ROCm documentation homepage is [rocm.docs.amd.com](https://rocm.docs.amd.com
 ### Building our documentation
 
 For a quick-start build, use the following code. For more options and detail, refer to
-[Building documentation](./contribute/building.md).
+[Building documentation](./docs/contribute/building.md).
 
 ```bash
 cd docs


### PR DESCRIPTION
Fix broken link to building.md in the README.  It was missing `/docs/` in the path.