### PR TITLE
Update doc requirements to 6.0.2 point fix

### DIFF
--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,1 +1,1 @@
-rocm-docs-core==0.35.1
+rocm-docs-core==0.37.1

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -84,9 +84,7 @@ pygments==2.15.0
     #   pydata-sphinx-theme
     #   sphinx
 pyjwt[crypto]==2.6.0
-    # via
-    #   pygithub
-    #   pyjwt
+    # via pygithub
 pynacl==1.5.0
     # via pygithub
 pytz==2022.7.1
@@ -100,7 +98,7 @@ requests==2.31.0
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==0.35.1
+rocm-docs-core==0.37.1
     # via -r requirements.in
 smmap==5.0.0
     # via gitdb


### PR DESCRIPTION
rocm-docs-core v0.37.1 should have the 6.0.2 header and no banner
