### PR TITLE
Add best practice for updating changelog

### DIFF
--- a/tools/autotag/README.md
+++ b/tools/autotag/README.md
@@ -13,8 +13,10 @@
 
 ## Updating the changelog
 
+> IMPORTANT: It is key to update the template Markdown files in `tools/autotag/templates/rocm_changes` (eg: `5.6.0.md`) and not the `CHANGELOG.md` itself to ensure that updates are not overwritten by the script
+
 * Add or update the release specific notes in `tools/autotag/templates/rocm_changes`
-* Ensure the all the repositories have their release specific branch with the updated changelogs.
+* Ensure the all the repositories have their release specific branch with the updated changelogs
 * Run this for 5.6.0 (change for whatever version you require)
 * `GITHUB_ACCESS_TOKEN=my_token_here`
 


### PR DESCRIPTION
IMPORTANT: It is key to update the template Markdown files in `tools/autotag/templates/rocm_changes` (eg: `5.6.0.md`) and not the `CHANGELOG.md` itself to ensure that updates are not overwritten by the script