### PR TITLE
Add rocDecode to API libraries

### DIFF
--- a/docs/reference/api-libraries.md
+++ b/docs/reference/api-libraries.md
@@ -23,6 +23,7 @@
 * {doc}`MIGraphX <amdmigraphx:index>`
 * {doc}`MIOpen <miopen:index>`
 * {doc}`MIVisionX <mivisionx:doxygen/html/index>`
+* {doc}`rocDecode <rocdecode:index>`
 * [ROCm Performance Primitives (RPP)](https://rocm.docs.amd.com/projects/rpp/en/latest/)
 :::
 


### PR DESCRIPTION
This PR adds a link to rocDecode in the API libraries table.