### PR TITLE
Merge develop into roc-6.1.x

### DIFF
--- a/docs/release/versions.md
+++ b/docs/release/versions.md
@@ -8,6 +8,7 @@
 
 | Version | Release date |
 | ------- | ------------ |
+| [6.1.0](https://rocm.docs.amd.com/en/docs-6.1.0/) | Apr 16, 2024 |
 | [6.0.2](https://rocm.docs.amd.com/en/docs-6.0.2/) | Jan 31, 2024 |
 | [6.0.0](https://rocm.docs.amd.com/en/docs-6.0.0/) | Dec 15, 2023 |
 | [5.7.1](https://rocm.docs.amd.com/en/docs-5.7.1/) | Oct 13, 2023 |


### PR DESCRIPTION
To include "Add ROCm version 6.1.0 to version list (#3023)"

Will be followed by PR from roc-6.1.x to docs/6.1.0