### PR TITLE
Add 'JAX for ROCm' link to index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ Our documentation is organized into the following categories:
   * {doc}`Windows install guide<rocm-install-on-windows:how-to/install>`
   * {doc}`Application deployment guidelines<rocm-install-on-windows:conceptual/deployment-guidelines>`
 * {doc}`Install Docker containers<rocm-install-on-linux:how-to/docker>`
+* {doc}`JAX for ROCm<rocm-install-on-linux:how-to/3rd-party/jax-install>`
 * {doc}`PyTorch for ROCm<rocm-install-on-linux:how-to/3rd-party/pytorch-install>`
 * {doc}`TensorFlow for ROCm<rocm-install-on-linux:how-to/3rd-party/tensorflow-install>`
 * {doc}`MAGMA for ROCm<rocm-install-on-linux:how-to/3rd-party/magma-install>`

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,9 +38,9 @@ Our documentation is organized into the following categories:
   * {doc}`Windows install guide<rocm-install-on-windows:how-to/install>`
   * {doc}`Application deployment guidelines<rocm-install-on-windows:conceptual/deployment-guidelines>`
 * {doc}`Install Docker containers<rocm-install-on-linux:how-to/docker>`
-* {doc}`JAX for ROCm<rocm-install-on-linux:how-to/3rd-party/jax-install>`
 * {doc}`PyTorch for ROCm<rocm-install-on-linux:how-to/3rd-party/pytorch-install>`
 * {doc}`TensorFlow for ROCm<rocm-install-on-linux:how-to/3rd-party/tensorflow-install>`
+* {doc}`JAX for ROCm<rocm-install-on-linux:how-to/3rd-party/jax-install>`
 * {doc}`MAGMA for ROCm<rocm-install-on-linux:how-to/3rd-party/magma-install>`
 * {doc}`ROCm & Spack<rocm-install-on-linux:how-to/spack>`
 :::


### PR DESCRIPTION
This PR adds a link to the JAX installation guide under `Install`.