### PR TITLE
Fix broken link on hardware specs page

### DIFF
--- a/docs/reference/gpu-arch-specs.rst
+++ b/docs/reference/gpu-arch-specs.rst
@@ -657,5 +657,5 @@ The following tables provide an overview of the hardware specifications for AMD 
           - 256
           - 12.5
 
-For more information on the terms used here, see the :ref:`specific documents and guides <gpu-arch-documentation>`, the :doc:`conceptual overview of the HIP programming model<hip:understand/programming_model>`, or the :doc:`HIP reference guide<hip:reference/programming_model>`.
+For more information on the terms used here, see the :ref:`specific documents and guides <gpu-arch-documentation>`, the :doc:`conceptual overview of the HIP programming model<hip:understand/programming_model>`, or the :doc:`HIP reference guide<hip:understand/programming_model_reference>`.
 

--- a/docs/reference/gpu-arch-specs.rst
+++ b/docs/reference/gpu-arch-specs.rst
@@ -657,5 +657,5 @@ The following tables provide an overview of the hardware specifications for AMD 
           - 256
           - 12.5
 
-For more information on the terms used here, see the :ref:`specific documents and guides <gpu-arch-documentation>`, the :doc:`conceptual overview of the HIP programming model<hip:understand/programming_model>`, or the :doc:`HIP reference guide<hip:understand/programming_model_reference>`.
+For more information on the terms used here, see the :ref:`specific documents and guides <gpu-arch-documentation>` or :doc:`Understanding the HIP programming model<hip:understand/programming_model>`.
 


### PR DESCRIPTION
This PR fixes a broken link on the hardware specs page to the HIP programming model reference due to refactoring of HIP docs.