### PR TITLE
Tagged builds of External CI components

### DIFF
--- a/.azuredevops/README.md
+++ b/.azuredevops/README.md
@@ -1,0 +1,30 @@
+# ROCm-CI Azure DevOps Pipelines
+
+ROCm-CI Azure DevOps Pipelines contains markup language files that orchestrate build and test pipelines for ROCm components using [Azure DevOps](https://dev.azure.com/ROCm-CI/ROCm-CI/_build).
+
+## Project Organization
+
+- `/.azuredevops/variables-global.yml` - set of global variables accessible across any and all pipelines
+  - protected keywords such as tokens and passwords are kept as secrets within the Azure DevOps project
+- `/.azuredevops/components` - the sequence of templated steps for the job that checks out source, builds, packages, and runs tests for a ROCm repo
+- `/.azuredevops/scheduled` - the sequence of templated steps for jobs that are schedule-based and not tied to a specific ROCm repo
+- `/.azuredevops/tag-builds` - yml files to orchestrate manual builds based on specific tags (e.g., releases) without needing the corresponding yaml file in the component's repo
+- `/.azuredevops/templates` - reusable yml files representing the templated steps that form the sequences in the above directories
+
+### Per ROCm Repo
+
+- `/.azuredevops/rocm-ci.yml` - contains the CI and PR trigger definitions associated with that repo, pointing to the corresponding yml file in the components folder in this central repository
+
+## Key Azure Reference Links
+
+- [Pipeline Basics](https://learn.microsoft.com/en-us/azure/devops/pipelines/get-started/key-pipelines-concepts?view=azure-devops)
+- [Templates](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops&pivots=templates-includes)
+- [Use Predefined Variables](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml)
+- [YAML schema](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/?view=azure-pipelines&viewFallbackFrom=azure-devops)
+- [Azure Pipelines Task Index](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/?view=azure-pipelines)
+
+## Disclaimer
+
+The information presented in this document is for informational purposes only and may contain technical inaccuracies, omissions, and typographical errors. The information contained herein is subject to change and may be rendered inaccurate for many reasons, including but not limited to product and roadmap changes, component and motherboard versionchanges, new model and/or product releases, product differences between differing manufacturers, software changes, BIOS flashes, firmware upgrades, or the like. Any computer system has risks of security vulnerabilities that cannot be completely prevented or mitigated.AMD assumes no obligation to update or otherwise correct or revise this information. However, AMD reserves the right to revise this information and to make changes from time to time to the content hereof without obligation of AMD to notify any person of such revisions or changes.THIS INFORMATION IS PROVIDED ‘AS IS.” AMD MAKES NO REPRESENTATIONS OR WARRANTIES WITH RESPECT TO THE CONTENTS HEREOF AND ASSUMES NO RESPONSIBILITY FOR ANY INACCURACIES, ERRORS, OR OMISSIONS THAT MAY APPEAR IN THIS INFORMATION. AMD SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR ANY PARTICULAR PURPOSE. IN NO EVENT WILL AMD BE LIABLE TO ANY PERSON FOR ANY RELIANCE, DIRECT, INDIRECT, SPECIAL, OR OTHER CONSEQUENTIAL DAMAGES ARISING FROM THE USE OF ANY INFORMATION CONTAINED HEREIN, EVEN IF AMD IS EXPRESSLY ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. AMD, the AMD Arrow logo, and combinations thereof are trademarks of Advanced Micro Devices, Inc. Other product names used in this publication are for identification purposes only and may be trademarks of their respective companies.
+
+© 2024 Advanced Micro Devices, Inc. All Rights Reserved.

--- a/.azuredevops/components/HIP.yml
+++ b/.azuredevops/components/HIP.yml
@@ -1,0 +1,101 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - libnuma-dev
+    - mesa-common-dev
+- name: pipModules
+  type: object
+  default:
+    - CppHeaderParser
+
+# hip and clr are tightly-coupled
+# run this same template for both repos
+# any changes for clr should just trigger HIP pipeline
+jobs:
+- job: hip_clr_combined
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+      pipModules: ${{ parameters.pipModules }}
+# checkout triggering repo (either HIP or clr)
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+# if this is triggered by HIP repo, matching repo is clr
+# if this is triggered by clr repo, matching repo is HIP
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: matching_repo
+# download tasks has built in 4x retry download count
+# these will download last passing build for that branch
+# CI case: download latest default branch build
+  - ${{ if eq(parameters.checkoutRef, '') }}:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: llvm-project
+        branchName: amd-staging
+        pipelineId: $(llvm-project-pipeline-id)
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: ROCT-Thunk-Interface
+        branchName: master
+        pipelineId: $(roct-thunk-interface-pipeline-id)
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: ROCR-Runtime
+        branchName: master
+        pipelineId: $(rocr-runtime-pipeline-id)
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: rocprofiler-register
+        branchName: amd-mainline
+        pipelineId: $(rocprofiler-register-pipeline-id)
+# manual build case: triggered by ROCm/ROCm repo
+  - ${{ if ne(parameters.checkoutRef, '') }}:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: \tag-builds\llvm-project
+        pipelineId: $(llvm-project-tagged-pipeline-id)
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: \tag-builds\ROCT-Thunk-Interface
+        pipelineId: $(roct-thunk-interface-tagged-pipeline-id)
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: \tag-builds\ROCR-Runtime
+        pipelineId: $(rocr-runtime-tagged-pipeline-id)
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: \tag-builds\rocprofiler-register
+        pipelineId: $(rocprofiler-register-tagged-pipeline-id)
+  - script: 'ls -1R $(Agent.BuildDirectory)/rocm'
+    displayName: 'Artifact listing'
+# compile clr
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      componentName: clr
+      cmakeBuildDir: 'clr/build'
+      extraBuildFlags: >-
+        -DHIP_COMMON_DIR="$(Build.SourcesDirectory)/HIP"
+        -DHIP_PLATFORM=amd
+        -DCMAKE_PREFIX_PATH="$(Agent.BuildDirectory)/rocm"
+        -DROCM_PATH="$(Agent.BuildDirectory)/rocm"
+        -DHIPCC_BIN_DIR="$(Agent.BuildDirectory)/rocm/bin"
+        -DCLR_BUILD_HIP=ON
+        -DCLR_BUILD_OCL=ON
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/HIPIFY.yml
+++ b/.azuredevops/components/HIPIFY.yml
@@ -1,0 +1,52 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - cmake
+    - ninja-build
+    - libnuma-dev
+
+jobs:
+- job: HIPIFY
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+# CI case: download latest default branch build
+  - ${{ if eq(parameters.checkoutRef, '') }}:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: llvm-project
+        branchName: amd-staging
+        pipelineId: $(llvm-project-pipeline-id)
+# manual build case: triggered by ROCm/ROCm repo
+  - ${{ if ne(parameters.checkoutRef, '') }}:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: \tag-builds\llvm-project
+        pipelineId: $(llvm-project-tagged-pipeline-id)
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      extraBuildFlags: >-
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_PREFIX_PATH="$(Agent.BuildDirectory)/rocm/llvm"
+        -DROCM_PATH="$(Agent.BuildDirectory)/rocm"
+        -GNinja
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/MIVisionX.yml
+++ b/.azuredevops/components/MIVisionX.yml
@@ -1,0 +1,39 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - cmake
+    - ninja-build
+
+jobs:
+- job: MIVisionX
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  container:
+    image: ${{ variables.DOCKER_IMAGE_NAME }}:${{ variables.LATEST_DOCKER_VERSION }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  - task: Bash@3
+    displayName: 'Dependency Setup'
+    inputs:
+      targetType: inline
+      script: 'python3 MIVisionX-setup.py'
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/ROCR-Runtime.yml
+++ b/.azuredevops/components/ROCR-Runtime.yml
@@ -1,0 +1,62 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - libelf-dev
+    - g++
+    - libdrm-dev
+    - libnuma-dev
+
+jobs:
+- job: ROCR_Runtime
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+# CI case: download latest default branch build
+  - ${{ if eq(parameters.checkoutRef, '') }}:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: llvm-project
+        branchName: amd-staging
+        pipelineId: $(llvm-project-pipeline-id)
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: ROCT-Thunk-Interface
+        branchName: master
+        pipelineId: $(roct-thunk-interface-pipeline-id)
+# manual build case: triggered by ROCm/ROCm repo
+  - ${{ if ne(parameters.checkoutRef, '') }}:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: \tag-builds\llvm-project
+        pipelineId: $(llvm-project-tagged-pipeline-id)
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: \tag-builds\ROCT-Thunk-Interface
+        pipelineId: $(roct-thunk-interface-tagged-pipeline-id)
+  - script: 'ls -1R $(Agent.BuildDirectory)/rocm'
+    displayName: 'Artifact listing'
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      extraBuildFlags: >-
+        -DCMAKE_PREFIX_PATH="$(Agent.BuildDirectory)/rocm"
+      cmakeBuildDir: 'src/build'
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/ROCT-Thunk-Interface.yml
+++ b/.azuredevops/components/ROCT-Thunk-Interface.yml
@@ -1,0 +1,32 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - libnuma-dev
+    - libdrm-dev
+
+jobs:
+- job: ROCT_Thunk_Interface
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/ROCdbgapi.yml
+++ b/.azuredevops/components/ROCdbgapi.yml
@@ -1,0 +1,38 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - cmake
+    - ninja-build
+
+jobs:
+- job: ROCdbgapi
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  container:
+    image: ${{ variables.DOCKER_IMAGE_NAME }}:${{ variables.LATEST_DOCKER_VERSION }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      extraBuildFlags: >-
+        -DCMAKE_BUILD_TYPE=Release
+        -GNinja
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/copyHIP.yml
+++ b/.azuredevops/components/copyHIP.yml
@@ -1,0 +1,32 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+
+# hip and clr are tightly-coupled
+# run this same template for both repos
+# any changes for clr should just trigger HIP pipeline
+jobs:
+- job: hip_clr_combined
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  workspace:
+    clean: all
+  steps:
+# checkout nothing, just copy artifacts from triggering HIP job
+# and then publish for this clr job to maintain latest
+  - checkout: none
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+    parameters:
+      componentName: HIP
+      branchName: develop
+  - template:  ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-prepare-package.yml
+    parameters:
+      sourceDir: $(Agent.BuildDirectory)/rocm
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/half.yml
+++ b/.azuredevops/components/half.yml
@@ -1,0 +1,41 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - cmake
+    - ninja-build
+
+jobs:
+- job: half
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  container:
+    image: ${{ variables.DOCKER_IMAGE_NAME }}:${{ variables.LATEST_DOCKER_VERSION }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      extraBuildFlags: >-
+        -DCMAKE_CXX_COMPILER=hipcc
+        -DCMAKE_BUILD_TYPE=Release
+        -DBUILD_CLIENTS=ON
+        -L
+        -GNinja
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/hipFFT.yml
+++ b/.azuredevops/components/hipFFT.yml
@@ -1,0 +1,47 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - cmake
+    - ninja-build
+    - rocrand
+    - hiprand
+    - rocfft
+    - libboost-program-options-dev
+    - googletest
+    - libfftw3-dev
+
+jobs:
+- job: hipFFT
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  container:
+    image: ${{ variables.DOCKER_IMAGE_NAME }}:${{ variables.LATEST_DOCKER_VERSION }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      extraBuildFlags: >-
+        -DCMAKE_CXX_COMPILER=hipcc
+        -DCMAKE_BUILD_TYPE=Release
+        -DBUILD_CLIENTS=ON
+        -L
+        -GNinja
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/hipSPARSE.yml
+++ b/.azuredevops/components/hipSPARSE.yml
@@ -1,0 +1,40 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - cmake
+    - libboost-program-options-dev
+    - googletest
+    - libfftw3-dev
+    - rocsparse
+    - git
+
+jobs:
+- job: hipSPARSE
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  container:
+    image: ${{ variables.DOCKER_IMAGE_NAME }}:${{ variables.LATEST_DOCKER_VERSION }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-script.yml
+    parameters:
+      scriptExecutable: sudo ./install.sh
+      scriptParameters: -c -i -d

--- a/.azuredevops/components/llvm-project.yml
+++ b/.azuredevops/components/llvm-project.yml
@@ -1,0 +1,112 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - cmake
+    - python3-pip
+    - libnuma-dev
+    - ninja-build
+    - ccache
+
+jobs:
+- job: llvm_project
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  - name: HIP_DEVICE_LIB_PATH
+    value: '$(Build.BinariesDirectory)/amdgcn/bitcode'
+  pool: ${{ variables.CLOUD_BUILD_POOL }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+# CI case: download latest default branch build
+  - ${{ if eq(parameters.checkoutRef, '') }}:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: rocm-cmake
+        branchName: develop
+        pipelineId: $(rocm-cmake-pipeline-id)
+        testFailuresOkay: true
+# manual build case: triggered by ROCm/ROCm repo
+  - ${{ if ne(parameters.checkoutRef, '') }}:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: \tag-builds\rocm-cmake
+        pipelineId: $(rocm-cmake-tagged-pipeline-id)
+        testFailuresOkay: true
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      componentName: rocm-llvm
+      extraBuildFlags: >-
+        -DCMAKE_PREFIX_PATH="$(Build.BinariesDirectory)/llvm;$(Build.BinariesDirectory)"
+        -DCMAKE_BUILD_TYPE=Release
+        -DLLVM_ENABLE_PROJECTS="llvm;clang;lld;clang-tools-extra"
+        -DLLVM_ENABLE_RUNTIMES="compiler-rt;libunwind"
+        -DCLANG_ENABLE_AMDCLANG="ON"
+        -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86"
+        -GNinja
+      cmakeBuildDir: 'llvm/build'
+      installDir: '$(Build.BinariesDirectory)/llvm'
+# use llvm-lit to run unit tests for llvm, clang, and lld
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
+    parameters:
+      componentName: check-llvm
+      testDir: 'llvm/build'
+      testExecutable: './bin/llvm-lit'
+      testParameters: '-q --xunit-xml-output=llvm_test_output.xml ./test'
+      testOutputFile: llvm_test_output.xml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
+    parameters:
+      componentName: check-clang
+      testDir: 'llvm/build'
+      testExecutable: './bin/llvm-lit'
+      testParameters: '-q --xunit-xml-output=clang_test_output.xml ./tools/clang/test'
+      testOutputFile: clang_test_output.xml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
+    parameters:
+      componentName: check-lld
+      testDir: 'llvm/build'
+      testExecutable: './bin/llvm-lit'
+      testParameters: '-q --xunit-xml-output=lld_test_output.xml ./tools/lld/test'
+      testOutputFile: lld_test_output.xml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      componentName: device-libs
+      extraBuildFlags: >-
+        -DCMAKE_PREFIX_PATH="$(Build.SourcesDirectory)/llvm/build"
+        -DCMAKE_BUILD_TYPE=Release
+      cmakeBuildDir: 'amd/device-libs/build'
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      componentName: comgr
+      extraBuildFlags: >-
+        -DCMAKE_PREFIX_PATH="$(Build.SourcesDirectory)/llvm/build;$(Build.SourcesDirectory)/amd/device-libs/build"
+        -DCMAKE_BUILD_TYPE=Release
+      cmakeBuildDir: 'amd/comgr/build'
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
+    parameters:
+      componentName: comgr
+      testParameters: '--output-on-failure --force-new-ctest-process --output-junit comgr_test_output.xml'
+      testDir: 'amd/comgr/build'
+      testOutputFile: comgr_test_output.xml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      componentName: hipcc
+      extraBuildFlags: >-
+        -DCMAKE_BUILD_TYPE=Release
+        -DHIPCC_BACKWARD_COMPATIBILITY=OFF
+      cmakeBuildDir: 'amd/hipcc/build'
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/rccl.yml
+++ b/.azuredevops/components/rccl.yml
@@ -1,0 +1,39 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - cmake
+    - libboost-program-options-dev
+    - googletest
+    - libfftw3-dev
+    - git
+
+jobs:
+- job: rccl
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  container:
+    image: ${{ variables.DOCKER_IMAGE_NAME }}:${{ variables.LATEST_DOCKER_VERSION }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-script.yml
+    parameters:
+      scriptExecutable: ./install.sh
+      scriptParameters: -d -t

--- a/.azuredevops/components/rocALUTION.yml
+++ b/.azuredevops/components/rocALUTION.yml
@@ -1,0 +1,40 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - cmake
+    - libboost-program-options-dev
+    - libgtest-dev
+    - libfftw3-dev
+    - git
+    - mpich
+
+jobs:
+- job: rocALUTION
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  container:
+    image: ${{ variables.DOCKER_IMAGE_NAME }}:${{ variables.LATEST_DOCKER_VERSION }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-script.yml
+    parameters:
+      scriptExecutable: ./install.sh
+      scriptParameters: -i -c -d

--- a/.azuredevops/components/rocDecode.yml
+++ b/.azuredevops/components/rocDecode.yml
@@ -1,0 +1,47 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - cmake
+    - ninja-build
+    - pkg-config
+    - ffmpeg
+    - libavcodec-dev
+    - libavformat-dev
+    - libavutil-dev
+    - libstdc++-12-dev
+    - mesa-amdgpu-multimedia-devel
+
+jobs:
+- job: rocDecode
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  container:
+    image: ${{ variables.DOCKER_IMAGE_NAME }}:${{ variables.LATEST_DOCKER_VERSION }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      extraBuildFlags: >-
+        -DCMAKE_BUILD_TYPE=Release
+        -DBUILD_CLIENTS=ON
+        -L
+        -GNinja
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/rocFFT.yml
+++ b/.azuredevops/components/rocFFT.yml
@@ -1,0 +1,48 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - cmake
+    - ninja-build
+    - rocrand
+    - hiprand
+    - libboost-program-options-dev
+    - libgtest-dev
+    - libfftw3-dev
+
+jobs:
+- job: rocFFT
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool: ${{ variables.CLOUD_BUILD_POOL }}
+  container:
+    image: ${{ variables.DOCKER_IMAGE_NAME }}:${{ variables.LATEST_DOCKER_VERSION }}
+  workspace:
+    clean: all
+  steps:
+ - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      extraBuildFlags: >-
+        -DCMAKE_CXX_COMPILER=hipcc
+        -DCMAKE_C_COMPILER=hipcc
+        -DCMAKE_PREFIX_PATH=/opt/rocm
+        -DCMAKE_BUILD_TYPE=Release
+        -DAMDGPU_TARGETS=gfx1100
+        -DUSE_HIP_CLANG=ON
+        -DHIP_COMPILER=clang
+        -GNinja
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/rocPRIM.yml
+++ b/.azuredevops/components/rocPRIM.yml
@@ -42,5 +42,4 @@ jobs:
         -DCMAKE_CXX_COMPILER=hipcc
         -DAMDGPU_TARGETS=gfx1100
         -GNinja
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/rocPRIM.yml
+++ b/.azuredevops/components/rocPRIM.yml
@@ -1,0 +1,47 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - cmake
+    - ninja-build
+    - libgtest-dev
+    - git
+
+jobs:
+- job: rocPRIM
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  container:
+    image: ${{ variables.DOCKER_IMAGE_NAME }}:${{ variables.LATEST_DOCKER_VERSION }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+# ${{ }} are resolved during compile-time
+# so this next step is skipped completely until
+# we define explicit aptPackages needed to install
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      extraBuildFlags: >-
+        -DBUILD_BENCHMARK=ON
+        -DCMAKE_CXX_COMPILER=hipcc
+        -DAMDGPU_TARGETS=gfx1100
+        -DAMDGPU_TARGETS=gfx1100
+        -GNinja
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/rocPRIM.yml
+++ b/.azuredevops/components/rocPRIM.yml
@@ -41,7 +41,6 @@ jobs:
         -DBUILD_BENCHMARK=ON
         -DCMAKE_CXX_COMPILER=hipcc
         -DAMDGPU_TARGETS=gfx1100
-        -DAMDGPU_TARGETS=gfx1100
         -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/rocThrust.yml
+++ b/.azuredevops/components/rocThrust.yml
@@ -1,0 +1,47 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - cmake
+    - ninja-build
+    - hiprand
+    - rocprim-dev
+    - libboost-program-options-dev
+    - googletest
+    - libfftw3-dev
+    - git
+
+jobs:
+- job: rocThrust
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  container:
+    image: ${{ variables.DOCKER_IMAGE_NAME }}:${{ variables.LATEST_DOCKER_VERSION }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      extraBuildFlags: >-
+        -GNinja
+        -DCMAKE_CXX_COMPILER=hipcc
+        -DROCM_PATH=/opt/rocm
+        -DCMAKE_PREFIX_PATH=/opt/rocm
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
+

--- a/.azuredevops/components/rocm-cmake.yml
+++ b/.azuredevops/components/rocm-cmake.yml
@@ -1,0 +1,48 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - doxygen
+    - doxygen-doc
+    - ninja-build
+    - python3-sphinx
+- name: pipModules
+  type: object
+  default:
+    - cget
+    - ninja
+
+jobs:
+- job: rocm_cmake
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+      pipModules: ${{ parameters.pipModules }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+# extra steps for ctest suite
+  - script: |
+      python -m pip install -r $(Build.SourcesDirectory)/docs/requirements.txt
+      python -m pip install -r $(Build.SourcesDirectory)/test/docsphinx/docs/.sphinx/requirements.txt
+      git config --global user.email "you@example.com"
+      git config --global user.name "Your Name"
+    displayName: "ctest setup"
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/rocm-core.yml
+++ b/.azuredevops/components/rocm-core.yml
@@ -1,0 +1,33 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+
+jobs:
+- job: rocm_core
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      extraBuildFlags: >-
+        -DCMAKE_CURRENT_BINARY_DIR=$PWD
+        -DCMAKE_CURRENT_SOURCE_DIR=$PWD/../
+        -DCMAKE_VERBOSE_MAKEFILE=1
+        -DCPACK_GENERATOR=DEB
+        -DCPACK_DEBIAN_PACKAGE_RELEASE="local.9999~99.99"
+        -DCPACK_RPM_PACKAGE_RELEASE="local.9999"
+        -DROCM_VERSION="$(last-release)"
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/rocm_bandwidth_test.yml
+++ b/.azuredevops/components/rocm_bandwidth_test.yml
@@ -1,0 +1,46 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - cmake
+    - ninja-build
+- name: pipModules
+  type: object
+  default:
+    - CppHeaderParser
+    - argparse
+
+jobs:
+- job: rocm_bandwidth_test
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  container:
+    image: ${{ variables.DOCKER_IMAGE_NAME }}:${{ variables.LATEST_DOCKER_VERSION }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+      pipModules: ${{ parameters.pipModules }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      extraBuildFlags: >-
+        -DCMAKE_BUILD_TYPE=release
+        -DCMAKE_MODULE_PATH="$(Build.SourcesDirectory)/cmake_modules"
+        -DCMAKE_PREFIX_PATH=/opt/rocm
+        -GNinja
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/rocminfo.yml
+++ b/.azuredevops/components/rocminfo.yml
@@ -1,0 +1,42 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+
+jobs:
+- job: rocminfo
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+# CI case: download latest default branch build
+  - ${{ if eq(parameters.checkoutRef, '') }}:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: ROCR-Runtime
+        branchName: master
+        pipelineId: $(rocr-runtime-pipeline-id)
+        testFailuresOkay: true
+# manual build case: triggered by ROCm/ROCm repo
+  - ${{ if ne(parameters.checkoutRef, '') }}:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: \tag-builds\ROCR-Runtime
+        pipelineId: $(rocr-runtime-tagged-pipeline-id)
+        testFailuresOkay: true
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      extraBuildFlags: >-
+        -DCMAKE_PREFIX_PATH="$(Agent.BuildDirectory)/rocm"
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/rocprofiler-register.yml
+++ b/.azuredevops/components/rocprofiler-register.yml
@@ -1,0 +1,24 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+
+jobs:
+- job: rocprofiler_register
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/rocprofiler.yml
+++ b/.azuredevops/components/rocprofiler.yml
@@ -1,0 +1,58 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - cmake
+    - libgtest-dev
+    - libdw-dev
+    - libsystemd-dev
+    - libelf-dev
+    - libnuma-dev
+    - libpciaccess-dev
+    - rocm-llvm-dev
+- name: pipModules
+  type: object
+  default:
+    - pyyaml==5.3.1
+    - Cppheaderparser
+    - websockets
+    - matplotlib
+    - lxml
+    - barectf
+    - pandas
+
+jobs:
+- job: rocprofiler
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  container:
+    image: ${{ variables.DOCKER_IMAGE_NAME }}:${{ variables.LATEST_DOCKER_VERSION }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+      pipModules: ${{ parameters.pipModules }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      extraBuildFlags: >-
+        -DCMAKE_MODULE_PATH="$(Build.SourcesDirectory)/cmake_modules;/opt/rocm/lib/cmake"
+        -DCMAKE_PREFIX_PATH="/opt/rocm"
+        -DENABLE_LDCONFIG=OFF
+        -DUSE_PROF_API=1
+        -DGPU_TARGETS="gfx1100"
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/rocr_debug_agent.yml
+++ b/.azuredevops/components/rocr_debug_agent.yml
@@ -1,0 +1,42 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - cmake
+    - ninja-build
+    - libelf-dev
+    - libdw-dev
+
+jobs:
+- job: rocr_debug_agent
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  container:
+    image: ${{ variables.DOCKER_IMAGE_NAME }}:${{ variables.LATEST_DOCKER_VERSION }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      extraBuildFlags: >-
+        -DCMAKE_BUILD_TYPE=Release
+        -DROCM_PATH=/opt/rocm
+        -DCMAKE_MODULE_PATH=/opt/rocm/lib/cmake
+        -GNinja
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/roctracer.yml
+++ b/.azuredevops/components/roctracer.yml
@@ -1,0 +1,61 @@
+parameters:
+- name: checkoutRepo
+  type: string
+  default: 'self'
+- name: checkoutRef
+  type: string
+  default: ''
+- name: aptPackages
+  type: object
+  default:
+    - cmake
+    - ninja-build
+- name: pipModules
+  type: object
+  default:
+    - CppHeaderParser
+    - argparse
+
+jobs:
+- job: roctracer
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool:
+    vmImage: ${{ variables.LOW_END_BUILD_POOL }}
+  container:
+    image: ${{ variables.DOCKER_IMAGE_NAME }}:${{ variables.LATEST_DOCKER_VERSION }}
+  workspace:
+    clean: all
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+      pipModules: ${{ parameters.pipModules }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+# CI case: download latest default branch build
+  - ${{ if eq(parameters.checkoutRef, '') }}:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: llvm-project
+        branchName: amd-staging
+        pipelineId: $(llvm-project-pipeline-id)
+# manual build case: triggered by ROCm/ROCm repo
+  - ${{ if ne(parameters.checkoutRef, '') }}:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: \tag-builds\llvm-project
+        pipelineId: $(llvm-project-tagged-pipeline-id)
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      extraBuildFlags: >-
+        -DCMAKE_BUILD_TYPE=release
+        -DCMAKE_MODULE_PATH="$(Agent.BuildDirectory)/rocm/lib/cmake"
+        -DCMAKE_PREFIX_PATH="$(Agent.BuildDirectory)/rocm/llvm;$(Agent.BuildDirectory)/rocm"
+        -DENABLE_LDCONFIG=OFF
+        -DGPU_TARGETS="gfx1100"
+        -GNinja
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/tag-builds/HIP.yml
+++ b/.azuredevops/tag-builds/HIP.yml
@@ -1,0 +1,33 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/HIP
+    ref: ${{ parameters.checkoutRef }}
+  - repository: matching_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/clr
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/HIP.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/HIPIFY.yml
+++ b/.azuredevops/tag-builds/HIPIFY.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/HIPIFY
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/HIPIFY.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/MIVisionX.yml
+++ b/.azuredevops/tag-builds/MIVisionX.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/MIVisionX
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/MIVisionX.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/ROCR-Runtime.yml
+++ b/.azuredevops/tag-builds/ROCR-Runtime.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCR-Runtime
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/ROCR-Runtime.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/ROCT-Thunk-Interface.yml
+++ b/.azuredevops/tag-builds/ROCT-Thunk-Interface.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCT-Thunk-Interface
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/ROCT-Thunk-Interface.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/ROCdbgapi.yml
+++ b/.azuredevops/tag-builds/ROCdbgapi.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCdbgapi
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/ROCdbgapi.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/half.yml
+++ b/.azuredevops/tag-builds/half.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/half
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/half.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/hipFFT.yml
+++ b/.azuredevops/tag-builds/hipFFT.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/hipFFT
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/hipFFT.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/hipSPARSE.yml
+++ b/.azuredevops/tag-builds/hipSPARSE.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/hipSPARSE
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/hipSPARSE.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/llvm-project.yml
+++ b/.azuredevops/tag-builds/llvm-project.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/llvm-project
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/llvm-project.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/rccl.yml
+++ b/.azuredevops/tag-builds/rccl.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/rccl
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rccl.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/rocALUTION.yml
+++ b/.azuredevops/tag-builds/rocALUTION.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/rocALUTION
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rocALUTION.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/rocDecode.yml
+++ b/.azuredevops/tag-builds/rocDecode.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/rocDecode
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rocDecode.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/rocFFT.yml
+++ b/.azuredevops/tag-builds/rocFFT.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/rocFFT
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rocFFT.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/rocPRIM.yml
+++ b/.azuredevops/tag-builds/rocPRIM.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/rocPRIM
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rocPRIM.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/rocThrust.yml
+++ b/.azuredevops/tag-builds/rocThrust.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/rocThrust
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rocThrust.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/rocm-cmake.yml
+++ b/.azuredevops/tag-builds/rocm-cmake.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/rocm-cmake
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rocm-cmake.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/rocm-core.yml
+++ b/.azuredevops/tag-builds/rocm-core.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/rocm-core
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rocm-core.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/rocm_bandwidth_test.yml
+++ b/.azuredevops/tag-builds/rocm_bandwidth_test.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/rocm_bandwidth_test
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rocm_bandwidth_test.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/rocminfo.yml
+++ b/.azuredevops/tag-builds/rocminfo.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/rocminfo
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rocminfo.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/rocprofiler-register.yml
+++ b/.azuredevops/tag-builds/rocprofiler-register.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/rocprofiler-register
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rocprofiler-register.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/rocprofiler.yml
+++ b/.azuredevops/tag-builds/rocprofiler.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/rocprofiler
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rocprofiler.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/rocr_debug_agent.yml
+++ b/.azuredevops/tag-builds/rocr_debug_agent.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/rocr_debug_agent
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rocr_debug_agent.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/tag-builds/roctracer.yml
+++ b/.azuredevops/tag-builds/roctracer.yml
@@ -1,0 +1,28 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/roctracer
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/roctracer.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/templates/steps/artifact-download.yml
+++ b/.azuredevops/templates/steps/artifact-download.yml
@@ -1,0 +1,39 @@
+parameters:
+# assumption componentName and pipeline name the same
+- name: componentName
+  type: string
+  default: ''
+- name: pipelineId
+  type: string
+  default: ''
+- name: branchName
+  type: string
+  default: '$(Build.SourceBranchName)' # for tagged builds
+- name: testFailuresOkay
+  type: boolean
+  default: false
+
+steps:
+- task: DownloadPipelineArtifact@2
+  displayName: Download ${{ parameters.componentName }}
+  inputs:
+    buildType: 'specific'
+    project: ROCm-CI
+    pipeline: ${{ parameters.pipelineId }}
+    specificBuildWithTriggering: true
+    allowPartiallySucceededBuilds: ${{ parameters.testFailuresOkay }}
+    branchName: ${{ parameters.branchName }}
+    targetPath: '$(System.ArtifactsDirectory)'
+- task: ExtractFiles@1
+  displayName: Extract ${{ parameters.componentName }}
+  inputs:
+    archiveFilePatterns: '$(System.ArtifactsDirectory)/**/*.tar.gz'
+    destinationFolder: '$(Agent.BuildDirectory)/rocm'
+    cleanDestinationFolder: false
+    overwriteExistingFiles: true
+- task: DeleteFiles@1
+  displayName: Cleanup Compressed ${{ parameters.componentName }}
+  inputs:
+    SourceFolder: '$(System.ArtifactsDirectory)'
+    Contents: '/**/*.tar.gz'
+    RemoveDotFiles: true

--- a/.azuredevops/templates/steps/artifact-upload.yml
+++ b/.azuredevops/templates/steps/artifact-upload.yml
@@ -1,0 +1,33 @@
+# compress build products into tarball
+# delete build products after compression
+# publish can be toggled off for jobs that produce multiple tarballs
+# for those cases, only publish the last call which puts all the tarballs in one container folder
+parameters:
+- name: artifactName # REQUIRED PARAMETER
+  type: string
+  default: 'drop'
+- name: publish
+  type: boolean
+  default: true
+
+steps:
+- task: ArchiveFiles@2
+  displayName: '${{ parameters.artifactName }} Compress'
+  inputs:
+    includeRootFolder: false
+    archiveType: 'tar'
+    tarCompression: 'gz'
+    archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.DefinitionName)_$(Build.SourceBranchName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_${{ parameters.artifactName }}.tar.gz'
+- task: DeleteFiles@1
+  displayName: 'Cleanup Staging Area'
+  inputs:
+    SourceFolder: '$(Build.BinariesDirectory)'
+    Contents: '/**/*'
+    RemoveDotFiles: true
+# then publish it
+- ${{ if parameters.publish }}:
+  - task: PublishPipelineArtifact@1
+    displayName: '${{ parameters.artifactName }} Publish'
+    retryCountOnTaskFailure: 3
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)'

--- a/.azuredevops/templates/steps/build-script.yml
+++ b/.azuredevops/templates/steps/build-script.yml
@@ -1,0 +1,22 @@
+parameters:
+- name: componentName
+  type: string
+  default: ''
+- name: scriptDir
+  type: string
+  default: '.'
+- name: scriptExecutable
+  type: string
+  default: './install.sh'
+- name: scriptParameters
+  type: string
+  default: ''
+
+steps:
+- task: Bash@3
+  displayName: '${{ parameters.componentName }} Building via script'
+  continueOnError: true
+  inputs:
+    targetType: inline
+    script: ${{ parameters.scriptExecutable }} ${{ parameters.scriptParameters }}
+    workingDirectory: ${{ parameters.scriptDir }}

--- a/.azuredevops/templates/steps/dependencies.yml
+++ b/.azuredevops/templates/steps/dependencies.yml
@@ -1,0 +1,38 @@
+parameters:
+# space-delimited list of packages to install via apt-get install command
+# TODO convert to string array and split with spaces
+- name: aptPackages
+  type: object
+  default: []
+- name: pipModules
+  type: object
+  default: []
+
+steps:
+- task: Bash@3
+  displayName: 'sudo apt-get update'
+  inputs:
+    targetType: inline
+    script: sudo apt-get update
+- task: Bash@3
+  displayName: 'sudo apt-get upgrade'
+  inputs:
+    targetType: inline
+    script: sudo apt-get update
+- task: Bash@3
+  displayName: 'sudo apt-get fix'
+  inputs:
+    targetType: inline
+    script: sudo apt --yes --fix-broken install
+- ${{ if gt(length(parameters.aptPackages), 0) }}:
+  - task: Bash@3
+    displayName: 'sudo apt-get install ...'
+    inputs:
+      targetType: inline
+      script: sudo apt-get --yes install ${{ join(' ', parameters.aptPackages) }}
+- ${{ if gt(length(parameters.pipModules), 0) }}:
+  - task: Bash@3
+    displayName: 'pip install  ...'
+    inputs:
+      targetType: inline
+      script: pip install ${{ join(' ', parameters.pipModules) }}

--- a/.azuredevops/templates/steps/preamble.yml
+++ b/.azuredevops/templates/steps/preamble.yml
@@ -1,0 +1,27 @@
+# build artifacts not automatically cleaned up
+# force cleanup, always
+# also display installed components and packages
+steps:
+- task: Bash@3
+  displayName: 'apt installed list'
+  inputs:
+    targetType: inline
+    script: apt list --installed
+- task: Bash@3
+  displayName: 'python version'
+  inputs:
+    targetType: inline
+    script: python3 --version
+- script: pip list
+  displayName: 'list python packages'
+- task: DeleteFiles@1
+  displayName: 'Cleanup checkout space'
+  inputs:
+    SourceFolder: '$(Agent.BuildDirectory)/s'
+    Contents: '**/*'
+- task: DeleteFiles@1
+  displayName: 'Cleanup Staging Area'
+  inputs:
+    SourceFolder: '$(Build.ArtifactStagingDirectory)'
+    Contents: '/**/*'
+    RemoveDotFiles: true

--- a/.azuredevops/variables-global.yml
+++ b/.azuredevops/variables-global.yml
@@ -1,0 +1,21 @@
+# specify non-secret global variables reused across pipelines here
+
+variables:
+- name: CI_ROOT_PATH
+  value: /.azuredevops
+- name: CI_COMPONENT_PATH
+  value: ${{ variables.CI_ROOT_PATH }}/components
+- name: CI_TEMPLATE_PATH
+  value: ${{ variables.CI_ROOT_PATH }}/templates
+- name: LOW_END_BUILD_POOL
+  value: ubuntu-22.04
+- name: HIGH_END_BUILD_POOL
+  value: rocm-ci_build_pool
+- name: CLOUD_BUILD_POOL
+  value: rocm-ci_cloud_build_pool
+- name: LATEST_RELEASE_TAG
+  value: rocm-6.1.0
+- name: DOCKER_IMAGE_NAME
+  value: rocm/dev-ubuntu-22.04
+- name: LATEST_DOCKER_VERSION
+  value: 6.1


### PR DESCRIPTION
Adding capability to kick off builds of ROCm components based on a tag ref, without the need of the yaml file in the corresponding repo that is used for pre-submit and on-submit builds. This unblocks the team from creating an initial set of pipelines to verify things work.

Also made some improvements to the code structure and added support for more repos.

Co-authored-by: abhimeda <abhinav.meda@amd.com>
Co-authored-by: alexxu-amd <alex.xu@amd.com>