### PR TITLE
External CI Tag Build Updates for Three Repos

### DIFF
--- a/.azuredevops/components/llvm-project.yml
+++ b/.azuredevops/components/llvm-project.yml
@@ -12,7 +12,7 @@ parameters:
     - python3-pip
     - libnuma-dev
     - ninja-build
-    - ccache
+    - python-is-python3
 
 jobs:
 - job: llvm_project
@@ -53,10 +53,12 @@ jobs:
       extraBuildFlags: >-
         -DCMAKE_PREFIX_PATH="$(Build.BinariesDirectory)/llvm;$(Build.BinariesDirectory)"
         -DCMAKE_BUILD_TYPE=Release
-        -DLLVM_ENABLE_PROJECTS="llvm;clang;lld;clang-tools-extra"
-        -DLLVM_ENABLE_RUNTIMES="compiler-rt;libunwind"
-        -DCLANG_ENABLE_AMDCLANG="ON"
-        -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86"
+        -DLLVM_ENABLE_PROJECTS=llvm;clang;lld;clang-tools-extra;mlir
+        -DLLVM_ENABLE_RUNTIMES=compiler-rt;libunwind;libcxx;libcxxabi
+        -DCLANG_ENABLE_AMDCLANG=ON
+        -DLLVM_TARGETS_TO_BUILD=AMDGPU;X86
+        -DROCM_LLVM_BACKWARD_COMPAT_LINK=$(Build.BinariesDirectory)/llvm
+        -DROCM_LLVM_BACKWARD_COMPAT_LINK_TARGET=./lib/llvm
         -GNinja
       cmakeBuildDir: 'llvm/build'
       installDir: '$(Build.BinariesDirectory)/llvm'

--- a/.azuredevops/components/rocMLIR.yml
+++ b/.azuredevops/components/rocMLIR.yml
@@ -16,7 +16,7 @@ jobs:
   variables:
   - group: common
   - template: /.azuredevops/variables-global.yml
-  pool: ${{ variables.HIGH_END_BUILD_POOL }}
+  pool: ${{ variables.CLOUD_BUILD_POOL }}
   container:
     image: ${{ variables.DOCKER_IMAGE_NAME }}:${{ variables.LATEST_DOCKER_VERSION }}
   workspace:

--- a/.azuredevops/components/rocMLIR.yml
+++ b/.azuredevops/components/rocMLIR.yml
@@ -10,51 +10,13 @@ parameters:
   default:
     - cmake
     - ninja-build
-    - git
-    - wget
-    - unzip
-    - pkg-config
-    - half
-    - rocblas-dev
-    - miopen-hip-dev
-    - migraphx-dev
-    - protobuf-compiler
-    - libprotoc-dev
-    - ffmpeg
-    - libavcodec-dev
-    - libavformat-dev
-    - libavutil-dev
-    - libswscale-dev
-    - rpp
-    - rpp-dev
-    - build-essential
-    - libgtk2.0-dev
-    - libavcodec-dev
-    - libavformat-dev
-    - libswscale-dev
-    - libtbb2
-    - libtbb-dev
-    - libjpeg-dev
-    - libpng-dev
-    - libtiff-dev
-    - libdc1394-dev
-    - libgmp-dev
-- name: pipModules
-  type: object
-  default:
-    - future==0.18.2
-    - pytz==2022.1
-    - numpy==1.21
-    - google==3.0.0
-    - protobuf==3.12.4
-    - onnx==1.12.0
 
 jobs:
-- job: MIVisionX
+- job: rocMLIR
   variables:
   - group: common
   - template: /.azuredevops/variables-global.yml
-  pool: ${{ variables.CLOUD_BUILD_POOL }}
+  pool: ${{ variables.HIGH_END_BUILD_POOL }}
   container:
     image: ${{ variables.DOCKER_IMAGE_NAME }}:${{ variables.LATEST_DOCKER_VERSION }}
   workspace:
@@ -63,7 +25,6 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies.yml
     parameters:
       aptPackages: ${{ parameters.aptPackages }}
-      pipModules: ${{ parameters.pipModules }}
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
     parameters:
@@ -72,9 +33,9 @@ jobs:
     parameters:
       extraBuildFlags: >-
         -DCMAKE_BUILD_TYPE=Release
-        -DROCM_PATH=/opt/rocm
-        -DBUILD_DEV=ON
-        -DROCM_DEP_ROCMCORE=ON
-        -DROCAL_PYTHON=OFF
+        -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++
+        -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang
+        -DCMAKE_PREFIX_PATH=/opt/rocm
+        -DBUILD_FAT_LIBROCKCOMPILER=1
         -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/tag-builds/rocMLIR.yml
+++ b/.azuredevops/tag-builds/rocMLIR.yml
@@ -1,0 +1,29 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: checkoutRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+  - repository: release_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/rocMLIR
+    ref: ${{ parameters.checkoutRef }}
+
+trigger: none
+pr: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rocMLIR.yml@pipelines_repo
+    parameters:
+      checkoutRepo: release_repo
+      checkoutRef: ${{ parameters.checkoutRef }}


### PR DESCRIPTION
- Updating build flags for llvm-project to support another pipeline to work with aomp repos.
- Added support for rocMLIR component.
- Removed MIVisionX python dependency script and leveraged existing dependencies template.