### PR TITLE
hipRAND: use azure pipeline artifacts instead of apt install

### DIFF
--- a/.azuredevops/components/hipRAND.yml
+++ b/.azuredevops/components/hipRAND.yml
@@ -12,7 +12,10 @@ parameters:
     - ninja-build
     - googletest
     - git
-    - rocrand
+- name: rocmDependencies
+  type: object
+  default:
+    - rocRAND
 
 jobs:
 - job: hipRAND
@@ -33,6 +36,18 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
     parameters:
       checkoutRepo: ${{ parameters.checkoutRepo }}
+# CI case: download latest default branch build
+  - ${{ if eq(parameters.checkoutRef, '') }}:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
+      parameters:
+        dependencyList: ${{ parameters.rocmDependencies }}
+        dependencySource: staging
+# manual build case: triggered by ROCm/ROCm repo
+  - ${{ if ne(parameters.checkoutRef, '') }}:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
+      parameters:
+        dependencyList: ${{ parameters.rocmDependencies }}
+        dependencySource: tag-builds
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
     parameters:
       extraBuildFlags: >-
@@ -40,7 +55,7 @@ jobs:
         -DCMAKE_C_COMPILER=/opt/rocm/bin/amdclang
         -DBUILD_TEST=ON
         -DCMAKE_MODULE_PATH="/opt/rocm/lib/cmake/hip"
-        -DCMAKE_PREFIX_PATH=/opt/rocm
+        -DCMAKE_PREFIX_PATH="$(Agent.BuildDirectory)/rocm;/opt/rocm"
         -DCMAKE_BUILD_TYPE=Release
         -DAMDGPU_TARGETS=gfx1030;gfx1100
         -DHIP_COMPILER=clang


### PR DESCRIPTION
For next phase of external CI project, use pipeline artifacts instead of apt install. Providing hipRAND as example for rest of team to follow.