### PR TITLE
External CI: Updating linker flags

### DIFF
--- a/.azuredevops/components/ROCR-Runtime.yml
+++ b/.azuredevops/components/ROCR-Runtime.yml
@@ -17,6 +17,7 @@ parameters:
   default:
     - llvm-project
     - ROCT-Thunk-Interface
+    - rocprofiler-register
 
 jobs:
 - job: ROCR_Runtime
@@ -53,5 +54,7 @@ jobs:
     parameters:
       extraBuildFlags: >-
         -DCMAKE_PREFIX_PATH="$(Agent.BuildDirectory)/rocm"
+        "-DCMAKE_EXE_LINKER_FLAGS_INIT=-Wl,--enable-new-dtags,--build-id=sha1,--rpath,$ORIGIN"
+        "-DCMAKE_SHARED_LINKER_FLAGS_INIT=-Wl,--enable-new-dtags,--build-id=sha1,--rpath,$ORIGIN/../lib"
       cmakeBuildDir: 'src/build'
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/llvm-project.yml
+++ b/.azuredevops/components/llvm-project.yml
@@ -13,6 +13,7 @@ parameters:
     - libnuma-dev
     - ninja-build
     - python-is-python3
+    - zlib1g-dev
 - name: rocmDependencies
   type: object
   default:
@@ -54,10 +55,36 @@ jobs:
       extraBuildFlags: >-
         -DCMAKE_PREFIX_PATH="$(Build.BinariesDirectory)/llvm;$(Build.BinariesDirectory)"
         -DCMAKE_BUILD_TYPE=Release
-        -DLLVM_ENABLE_PROJECTS=llvm;clang;lld;clang-tools-extra;mlir
+        -DLLVM_ENABLE_PROJECTS=clang;lld;clang-tools-extra;mlir
         -DLLVM_ENABLE_RUNTIMES=compiler-rt;libunwind;libcxx;libcxxabi
         -DCLANG_ENABLE_AMDCLANG=ON
         -DLLVM_TARGETS_TO_BUILD=AMDGPU;X86
+        -DLIBCXX_ENABLE_SHARED=OFF
+        -DLIBCXX_ENABLE_STATIC=ON
+        -DLIBCXX_INSTALL_LIBRARY=OFF
+        -DLIBCXX_INSTALL_HEADERS=OFF
+        -DLIBCXXABI_ENABLE_SHARED=OFF
+        -DLIBCXXABI_ENABLE_STATIC=ON
+        -DLIBCXXABI_INSTALL_STATIC_LIBRARY=OFF
+        -DLLVM_BUILD_DOCS=OFF
+        -DLLVM_ENABLE_SPHINX=OFF
+        -DSPHINX_WARNINGS_AS_ERRORS=OFF
+        -DSPHINX_OUTPUT_MAN=OFF
+        -DLLVM_ENABLE_ASSERTIONS=OFF
+        -DLLVM_ENABLE_Z3_SOLVER=OFF
+        -DLLVM_ENABLE_ZLIB=ON
+        -DCLANG_DEFAULT_LINKER=lld
+        -DCLANG_DEFAULT_RTLIB=compiler-rt
+        -DCLANG_DEFAULT_UNWINDLIB=libgcc
+        -DSANITIZER_AMDGPU=OFF
+        -DPACKAGE_VENDOR="AMD"
+        -DCMAKE_SKIP_BUILD_RPATH=TRUE
+        -DCMAKE_SKIP_INSTALL_RPATH=TRUE
+        "-DCMAKE_EXE_LINKER_FLAGS_INIT=-Wl,--enable-new-dtags,--build-id=sha1,--rpath,$ORIGIN"
+        "-DCMAKE_SHARED_LINKER_FLAGS_INIT=-Wl,--enable-new-dtags,--build-id=sha1,--rpath,$ORIGIN/../lib"
+        -DCLANG_LINK_FLANG_LEGACY=ON
+        -DCMAKE_CXX_STANDARD=17
+        -DFLANG_INCLUDE_DOCS=OFF
         -DROCM_LLVM_BACKWARD_COMPAT_LINK=$(Build.BinariesDirectory)/llvm
         -DROCM_LLVM_BACKWARD_COMPAT_LINK_TARGET=./lib/llvm
         -GNinja

--- a/.azuredevops/components/rocminfo.yml
+++ b/.azuredevops/components/rocminfo.yml
@@ -40,4 +40,8 @@ jobs:
     parameters:
       extraBuildFlags: >-
         -DCMAKE_PREFIX_PATH="$(Agent.BuildDirectory)/rocm"
+        -DCMAKE_SKIP_BUILD_RPATH=TRUE
+        -DROCRTST_BLD_TYPE=release
+        "-DCMAKE_EXE_LINKER_FLAGS_INIT=-Wl,--enable-new-dtags,--build-id=sha1,--rpath,$ORIGIN"
+        "-DCMAKE_SHARED_LINKER_FLAGS_INIT=-Wl,--enable-new-dtags,--build-id=sha1,--rpath,$ORIGIN/../lib"
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml


### PR DESCRIPTION
After examining the build products of recent builds and consuming them for other components, observed some additional flags should be added. Used rocm-build repo for reference.