### PR TITLE
CODEOWNERS nested folders pattern

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 * @amd-aakash @jlgreathouse @samjwu @yhuiYH @ROCm/rocm-documentation
 # Documentation files
-docs/* @amd-aakash @jlgreathouse @samjwu @yhuiYH @ROCm/rocm-documentation
+docs/ @amd-aakash @jlgreathouse @samjwu @yhuiYH @ROCm/rocm-documentation
 *.md @amd-aakash @jlgreathouse @samjwu @yhuiYH @ROCm/rocm-documentation
 *.rst @amd-aakash @jlgreathouse @samjwu @yhuiYH @ROCm/rocm-documentation
 # External CI
-/.azuredevops/* @ROCm/external-ci
+/.azuredevops/ @ROCm/external-ci


### PR DESCRIPTION
As documented in the link below, patterns ending with "/*" do not include further nested files and folders. Desired behaviour is to catch these further nested files and folders.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners