### PR TITLE
Fix ROCm SMI changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,9 +70,32 @@ HIPCC for ROCm 6.1.1
 
 ROCm SMI for ROCm 6.1.1
 
+##### Additions
+
+* Added the capability to unlock mutex when a process is dead. Added related debug output.
+* Added the `Partition ID` field to the `rocm-smi` CLI.
+* Added `NODE`, `GUID`, and `GFX Version` fields to the CLI.
+* Documentation now includes C++ and Python tutorials, API guides, and reference material.
+
+##### Changes
+
+* Some `rocm-smi` fields now display `N/A` instead of `unknown/unsupported` for consistency.
+* Changed stacked ID formatting in the `rocm-smi` CLI to make it easier to spot identifiers.
+
+##### Fixes
+
+* Fixed HIP and ROCm SMI mismatch on GPU bus assignments.
+* Fixed memory leaks caused by not closing directories and creating maps nodes instead of using `.at()`.
+* Fixed initializing calls which reuse `rocmsmi.initializeRsmi()` bindings in the `rocmsmi` Python API.
+* Fixed an issue causing `rsmi_dev_activity_metric_get` gfx/memory to not update with GPU activity.
+
 ##### Known issues
 
 * ROCm SMI reports GPU utilization incorrectly for RDNA3 GPUs in some situations. See the issue on [GitHub](https://github.com/ROCm/ROCm/issues/3112).
+
+```{note}
+See the [detailed ROCm SMI changelog](https://github.com/ROCm/rocm_smi_lib/blob/docs/6.1.1/CHANGELOG.md) with code samples for more information.
+```
 
 ### Library changes in ROCm 6.1.1
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -62,9 +62,32 @@ HIPCC for ROCm 6.1.1
 
 ROCm SMI for ROCm 6.1.1
 
+### Additions
+
+* Added the capability to unlock mutex when a process is dead. Added related debug output.
+* Added the `Partition ID` field to the `rocm-smi` CLI.
+* Added `NODE`, `GUID`, and `GFX Version` fields to the CLI.
+* Documentation now includes C++ and Python tutorials, API guides, and reference material.
+
+### Changes
+
+* Some `rocm-smi` fields now display `N/A` instead of `unknown/unsupported` for consistency.
+* Changed stacked ID formatting in the `rocm-smi` CLI to make it easier to spot identifiers.
+
+### Fixes
+
+* Fixed HIP and ROCm SMI mismatch on GPU bus assignments.
+* Fixed memory leaks caused by not closing directories and creating maps nodes instead of using `.at()`.
+* Fixed initializing calls which reuse `rocmsmi.initializeRsmi()` bindings in the `rocmsmi` Python API.
+* Fixed an issue causing `rsmi_dev_activity_metric_get` gfx/memory to not update with GPU activity.
+
 ### Known issues
 
 - ROCm SMI reports GPU utilization incorrectly for RDNA3 GPUs in some situations. See the issue on [GitHub](https://github.com/ROCm/ROCm/issues/3112).
+
+```{note}
+See the [detailed ROCm SMI changelog](https://github.com/ROCm/rocm_smi_lib/blob/docs/6.1.1/CHANGELOG.md) with code samples for more information.
+```
 
 ## Library changes in ROCm 6.1.1
 
@@ -97,11 +120,11 @@ ROCm SMI for ROCm 6.1.1
 | rpp         | [1.5.0](https://github.com/ROCm/rpp/releases/tag/rocm-6.1.1)               |
 | Tensile     | [4.40.0](https://github.com/ROCm/Tensile/releases/tag/rocm-6.1.1)          |
 
-#### hipBLASLt 0.7.0
+### hipBLASLt 0.7.0
 
 hipBLASLt 0.7.0 for ROCm 6.1.1
 
-##### Additions
+#### Additions
 
 - Added `hipblasltExtSoftmax` extension API.
 - Added `hipblasltExtLayerNorm` extension API.
@@ -109,7 +132,7 @@ hipBLASLt 0.7.0 for ROCm 6.1.1
 - Added `GemmTuning` extension parameter to set split-k by user.
 - Added support for mixed precision datatype: fp16/fp8 in with fp16 outk.
 
-##### Deprecations
+#### Deprecations
 
 - **Upcoming**: `algoGetHeuristic()` ext API for GroupGemm will be deprecated in a future release of hipBLASLt.
 

--- a/tools/autotag/templates/rocm_changes/6.1.1.md
+++ b/tools/autotag/templates/rocm_changes/6.1.1.md
@@ -52,6 +52,29 @@ HIPCC for ROCm 6.1.1
 
 ROCm SMI for ROCm 6.1.1
 
+#### Additions
+
+* Added the capability to unlock mutex when a process is dead. Added related debug output.
+* Added the `Partition ID` field to the `rocm-smi` CLI.
+* Added `NODE`, `GUID`, and `GFX Version` fields to the CLI.
+* Documentation now includes C++ and Python tutorials, API guides, and reference material.
+
+#### Changes
+
+* Some `rocm-smi` fields now display `N/A` instead of `unknown/unsupported` for consistency.
+* Changed stacked ID formatting in the `rocm-smi` CLI to make it easier to spot identifiers.
+
+#### Fixes
+
+* Fixed HIP and ROCm SMI mismatch on GPU bus assignments.
+* Fixed memory leaks caused by not closing directories and creating maps nodes instead of using `.at()`.
+* Fixed initializing calls which reuse `rocmsmi.initializeRsmi()` bindings in the `rocmsmi` Python API.
+* Fixed an issue causing `rsmi_dev_activity_metric_get` gfx/memory to not update with GPU activity.
+
 #### Known issues
 
 * ROCm SMI reports GPU utilization incorrectly for RDNA3 GPUs in some situations. See the issue on [GitHub](https://github.com/ROCm/ROCm/issues/3112).
+
+```{note}
+See the [detailed ROCm SMI changelog](https://github.com/ROCm/rocm_smi_lib/blob/docs/6.1.1/CHANGELOG.md) with code samples for more information.
+```


### PR DESCRIPTION
This PR adds missed ROCm SMI notes to the consolidated changelog.