### PR TITLE
Update default.xml

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
     <remote name="rocm-org" fetch="https://github.com/ROCm/" />
+    <remote name="KhronosGroup" fetch="https://github.com/KhronosGroup/" />
     <default revision="refs/tags/rocm-6.1.1"
      remote="rocm-org"
      sync-c="true"


### PR DESCRIPTION
Remote name for KhronosGroup is missing from the default.xml:

https://github.com/ROCm/ROCm/pull/3098/files#diff-d9b8e4a48f8e111ec5d21480d9d33a893b365dfa7f8550bbc0577e4d42afeac8L4