### PR TITLE
Some new external CI dependencies for latest source on default branches

### DIFF
--- a/.azuredevops/components/rdc.yml
+++ b/.azuredevops/components/rdc.yml
@@ -27,6 +27,7 @@ parameters:
     - clr
     - rocminfo
     - rocm-smi-lib
+    - amdsmi
 
 jobs:
 - job: rdc

--- a/.azuredevops/components/rocBLAS.yml
+++ b/.azuredevops/components/rocBLAS.yml
@@ -51,8 +51,6 @@ jobs:
     value: $(Agent.BuildDirectory)/rocm/bin/hipcc
   - name: TENSILE_ROCM_OFFLOAD_BUNDLER_PATH
     value: $(Agent.BuildDirectory)/rocm/llvm/bin/clang-offload-bundler
-  - name: PATH
-    value: $(Agent.BuildDirectory)/rocm/llvm/bin:$(Agent.BuildDirectory)/rocm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
   pool: ${{ variables.MEDIUM_BUILD_POOL }}
   workspace:
     clean: all
@@ -67,12 +65,36 @@ jobs:
       checkoutRepo: ${{ parameters.checkoutRepo }}
 # CI case: download latest default branch build
   - ${{ if eq(parameters.checkoutRef, '') }}:
+    - task: Bash@3
+      displayName: 'Download AOCL'
+      inputs:
+        targetType: inline
+        script: wget -nv https://download.amd.com/developer/eula/aocl/aocl-4-2/aocl-linux-gcc-4.2.0_1_amd64.deb
+        workingDirectory: '$(Pipeline.Workspace)'
+    - task: Bash@3
+      displayName: 'Install AOCL'
+      inputs:
+        targetType: inline
+        script: sudo apt install --yes ./aocl-linux-gcc-4.2.0_1_amd64.deb
+        workingDirectory: '$(Pipeline.Workspace)'
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         dependencyList: ${{ parameters.rocmDependencies }}
         dependencySource: staging
 # manual build case: triggered by ROCm/ROCm repo
   - ${{ if ne(parameters.checkoutRef, '') }}:
+    - task: Bash@3
+      displayName: 'Download AOCL'
+      inputs:
+        targetType: inline
+        script: wget -nv https://download.amd.com/developer/eula/aocl/aocl-4-1/aocl-linux-aocc-4.1.0_1_amd64.deb
+        workingDirectory: '$(Pipeline.Workspace)'
+    - task: Bash@3
+      displayName: 'Install AOCL'
+      inputs:
+        targetType: inline
+        script: sudo apt install --yes ./aocl-linux-aocc-4.1.0_1_amd64.deb
+        workingDirectory: '$(Pipeline.Workspace)'
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         dependencyList: ${{ parameters.rocmDependencies }}

--- a/.azuredevops/components/rocPRIM.yml
+++ b/.azuredevops/components/rocPRIM.yml
@@ -58,7 +58,7 @@ jobs:
       extraBuildFlags: >-
         -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
         -DBUILD_BENCHMARK=ON
-        -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/amdclang++
+        -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
         -DAMDGPU_TARGETS=gfx1030;gfx1100
         -DBUILD_TEST=ON
         -GNinja

--- a/.azuredevops/templates/steps/artifact-download.yml
+++ b/.azuredevops/templates/steps/artifact-download.yml
@@ -12,6 +12,7 @@ parameters:
 - name: defaultBranchList
   type: object
   default:
+    amdsmi: develop
     aomp: aomp-dev
     aomp-extras: aomp-dev
     AMDMIGraphX: develop

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -23,6 +23,7 @@ parameters:
 - name: stagingPipelineIdentifiers
   type: object
   default:
+    amdsmi: $(amdsmi-pipeline-id)
     aomp: $(aomp-pipeline-id)
     aomp-extras: $(aomp-extras-pipeline-id)
     AMDMIGraphX: $(amdmigraphx-pipeline-id)
@@ -57,6 +58,7 @@ parameters:
 - name: taggedPipelineIdentifiers
   type: object
   default:
+    amdsmi: $(amdsmi-tagged-pipeline-id)
     aomp: $(aomp-tagged-pipeline-id)
     aomp-extras: $(aomp-extras-tagged-pipeline-id)
     AMDMIGraphX: $(amdmigraphx-tagged-pipeline-id)


### PR DESCRIPTION
rocBLAS: [AOCL gcc 4.2 for newer builds, use AOCL aocc 4.1 for 6.1.0 tag](https://github.com/ROCm/rocBLAS/blob/develop/clients/CMakeLists.txt#L119)
rocPRIM: incorrect compiler path
rdc: amdsmi

**_Logs of successful builds_**

**rocBLAS**
- [tag-build](https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=1398&view=logs&j=97ce699c-40dd-5ae9-b9e5-e645874cb04a)
- [staging](https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=1397&view=logs&j=97ce699c-40dd-5ae9-b9e5-e645874cb04a)

**rocPRIM**
- [tag-build](https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=1399&view=logs&j=23986c94-575d-52f0-82b6-2a50ff31b4d4)
- [staging](https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=1402&view=logs&j=23986c94-575d-52f0-82b6-2a50ff31b4d4)

**rdc**
- [tag-build](https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=1400&view=logs&j=62d77707-4524-50fc-ec54-fa5715f65513)
- [staging](https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=1401&view=logs&j=62d77707-4524-50fc-ec54-fa5715f65513)
- staging fails but amdsmi dependency addition can be committed as tag-build passes

To test staging build in this scenario, the checkoutRef if statements in component yml file was changed from empty string '' to ''develop' (or whatever default branch name is for component) and the passed parameter for checkoutRef when manually kicking off job is that default branch name.