### PR TITLE
Disable PDF on 6.1.0

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,4 +15,4 @@ python:
    install:
    - requirements: docs/sphinx/requirements.txt
 
-formats: [htmlzip, pdf, epub]
+formats: [htmlzip, epub]


### PR DESCRIPTION
These are causing RTD builds to time out
