### PR TITLE
MIOpen External CI: Add rocprofiler-register dependency

### DIFF
--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -27,6 +27,7 @@ parameters:
     - rocm-cmake
     - llvm-project
     - ROCR-Runtime
+    - rocprofiler-register
     - clr
     - rocminfo
 


### PR DESCRIPTION
Attempts with latest source shows CMake error, searching for rocprofiler-register.