### PR TITLE
External CI: updated cmake dependencies

### DIFF
--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -8,14 +8,12 @@ parameters:
 - name: aptPackages
   type: object
   default:
-    - cmake
     - ninja-build
     - python3-venv
     - libmsgpack-dev
     - git
     - python3-pip
     - libdrm-dev
-
 - name: pipModules
   type: object
   default:
@@ -29,7 +27,6 @@ parameters:
     - rocminfo
     - rocprofiler-register
     - hipBLAS
-
 
 jobs:
 - job: hipBLASLt
@@ -49,8 +46,6 @@ jobs:
   - name: PATH
     value: $(Agent.BuildDirectory)/rocm/llvm/bin:$(Agent.BuildDirectory)/rocm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
   pool: ${{ variables.MEDIUM_BUILD_POOL }}
-  
-  
   workspace:
     clean: all
   steps:
@@ -58,6 +53,7 @@ jobs:
     parameters:
       aptPackages: ${{ parameters.aptPackages }}
       pipModules: ${{ parameters.pipModules }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-cmake-latest.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
     parameters:
@@ -73,8 +69,9 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         dependencyList: ${{ parameters.rocmDependencies }}
-        dependencySource: tag-builds 
+        dependencySource: tag-builds
   - script: sudo ln -s $(Agent.BuildDirectory)/rocm /opt/rocm
+    displayName: ROCm symbolic link
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
     parameters:
       extraBuildFlags: >-

--- a/.azuredevops/components/hipSPARSELt.yml
+++ b/.azuredevops/components/hipSPARSELt.yml
@@ -8,7 +8,6 @@ parameters:
 - name: aptPackages
   type: object
   default:
-    - cmake
     - ninja-build
     - python3-venv
     - libmsgpack-dev
@@ -53,6 +52,7 @@ jobs:
     parameters:
       aptPackages: ${{ parameters.aptPackages }}
       pipModules: ${{ parameters.pipModules }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-cmake-latest.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
     parameters:
@@ -68,8 +68,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         dependencyList: ${{ parameters.rocmDependencies }}
-        dependencySource: tag-builds 
-  - script: pwd
+        dependencySource: tag-builds
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
     parameters:
       extraBuildFlags: >-

--- a/.azuredevops/templates/steps/dependencies-cmake-latest.yml
+++ b/.azuredevops/templates/steps/dependencies-cmake-latest.yml
@@ -1,0 +1,10 @@
+# replace cmake from apt install with newest version using snap install
+steps:
+- task: Bash@3
+  displayName: update cmake
+  inputs:
+    targetType: inline
+    script: |
+      sudo apt purge cmake
+      sudo snap install cmake --classic
+      hash -r


### PR DESCRIPTION
Template with bash commands to update cmake with snap. Ubuntu apt tool only has up to version 3.22, while snap can install 3.28. Use template for two components that want updated cmake with latest source on their default branches.

### Build Logs with updated cmake

- [hipBLASLt](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=1460&view=logs&j=00131318-001f-5906-71a1-f3ec7b45eb0a)
- [hipSPARSELt](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=1461&view=logs&j=8073db15-de3f-58b2-17da-8a189bfd1bbe)