### PR TITLE
External CI: Add rocBLAS dependency to rocSPARSE

### DIFF
--- a/.azuredevops/components/rocSPARSE.yml
+++ b/.azuredevops/components/rocSPARSE.yml
@@ -49,13 +49,13 @@ jobs:
     parameters:
       checkoutRepo: ${{ parameters.checkoutRepo }}
   # CI case: download latest default branch build
-  - ${{ if eq(parameters.checkoutRef, 'develop') }}:
+  - ${{ if eq(parameters.checkoutRef, '') }}:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         dependencyList: ${{ parameters.rocmDependencies }}
         dependencySource: staging
   # manual build case: triggered by ROCm/ROCm repo
-  - ${{ if ne(parameters.checkoutRef, 'develop') }}:
+  - ${{ if ne(parameters.checkoutRef, '') }}:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         dependencyList: ${{ parameters.rocmDependencies }}

--- a/.azuredevops/components/rocSPARSE.yml
+++ b/.azuredevops/components/rocSPARSE.yml
@@ -49,13 +49,13 @@ jobs:
     parameters:
       checkoutRepo: ${{ parameters.checkoutRepo }}
   # CI case: download latest default branch build
-  - ${{ if eq(parameters.checkoutRef, '') }}:
+  - ${{ if eq(parameters.checkoutRef, 'develop') }}:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         dependencyList: ${{ parameters.rocmDependencies }}
         dependencySource: staging
   # manual build case: triggered by ROCm/ROCm repo
-  - ${{ if ne(parameters.checkoutRef, '') }}:
+  - ${{ if ne(parameters.checkoutRef, 'develop') }}:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         dependencyList: ${{ parameters.rocmDependencies }}

--- a/.azuredevops/components/rocSPARSE.yml
+++ b/.azuredevops/components/rocSPARSE.yml
@@ -25,6 +25,7 @@ parameters:
     - llvm-project
     - ROCR-Runtime
     - clr
+    - rocBLAS
     - rocminfo
     - rocPRIM
     - rocprofiler-register


### PR DESCRIPTION
rocSPARSE depends on rocBLAS, but it still builds without it and just throws a cmake warning. This PR adds rocBLAS into rocmDependencies.

Old build warning:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=1317&view=logs&j=b335d58d-d817-50f2-cd88-76ba01a68267&t=6e9ead50-31a2-5bcc-39ce-48fea8e7df2e&l=136

New build:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=1549&view=logs&j=b335d58d-d817-50f2-cd88-76ba01a68267&t=6e9ead50-31a2-5bcc-39ce-48fea8e7df2e&l=57