### PR TITLE
Remove branch filter for aomp pipeline trigger

### DIFF
--- a/.azuredevops/ci-builds/aomp.yml
+++ b/.azuredevops/ci-builds/aomp.yml
@@ -17,11 +17,7 @@ resources:
   pipelines:
   - pipeline: rocr-runtime_pipeline
     source: \ROCR-Runtime
-    trigger:
-      branches:
-        include:
-        - master
-
+    trigger: true
 # this job will only be triggered after successful build sequence of llvm-project and ROCR-Runtime
 
 trigger: none


### PR DESCRIPTION
Previous filter was not triggering this CI pipeline when ROCm-Runtime build was triggered from a pipeline completion trigger of llvm-project.