### PR TITLE
Change composable_kernel CI pipeline to build for all architectures

### DIFF
--- a/.azuredevops/components/composable_kernel.yml
+++ b/.azuredevops/components/composable_kernel.yml
@@ -24,10 +24,11 @@ parameters:
 
 jobs:
 - job: composable_kernel
+  timeoutInMinutes: 210
   variables:
   - group: common
   - template: /.azuredevops/variables-global.yml
-  pool: ${{ variables.MEDIUM_BUILD_POOL }}
+  pool: ${{ variables.ULTRA_BUILD_POOL }}
   workspace:
     clean: all
   steps:
@@ -57,6 +58,6 @@ jobs:
         -DCMAKE_C_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang
         -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
         -DCMAKE_BUILD_TYPE=Release
-        -DGPU_TARGETS=gfx1030;gfx1100
+        -DINSTANCE_ONLY=ON
         -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml


### PR DESCRIPTION
Add cmake flag to build instance only, since tests for different architectures cannot be built together.
Change pool to ultra and increase time limit to 3.5 hours.