### PR TITLE
External CI: Update aqlprofile binary used for rocprofiler

### DIFF
--- a/.azuredevops/components/rocprofiler.yml
+++ b/.azuredevops/components/rocprofiler.yml
@@ -47,7 +47,7 @@ jobs:
   variables:
   - group: common
   - template: /.azuredevops/variables-global.yml
-  - name: HIP_ROCCLR_HOME 
+  - name: HIP_ROCCLR_HOME
     value: $(Agent.BuildDirectory)/rocm
   - name: ROCM_PATH
     value: $(Agent.BuildDirectory)/rocm
@@ -68,7 +68,7 @@ jobs:
     displayName: 'Download aqlprofile'
     inputs:
       targetType: inline
-      script: wget -nv https://repo.radeon.com/rocm/apt/6.1/pool/main/h/hsa-amd-aqlprofile/hsa-amd-aqlprofile_1.0.0.60100.60100-82~22.04_amd64.deb
+      script: wget -nv https://repo.radeon.com/rocm/misc/aqlprofile/ubuntu-22.04/hsa-amd-aqlprofile_1.0.0.60200.60200-crdnnh.14213~22.04_amd64.deb
       workingDirectory: '$(Pipeline.Workspace)'
   - task: Bash@3
     displayName: 'Extract aqlprofile'
@@ -76,7 +76,7 @@ jobs:
       targetType: inline
       script: |
         mkdir hsa-amd-aqlprofile
-        dpkg-deb -R hsa-amd-aqlprofile_1.0.0.60100.60100-82~22.04_amd64.deb hsa-amd-aqlprofile
+        dpkg-deb -R hsa-amd-aqlprofile_1.0.0.60200.60200-crdnnh.14213~22.04_amd64.deb hsa-amd-aqlprofile
       workingDirectory: '$(Pipeline.Workspace)'
   - task: Bash@3
     displayName: 'Move aqlprofile'
@@ -84,7 +84,7 @@ jobs:
       targetType: inline
       script: |
         mkdir -p $(Agent.BuildDirectory)/rocm
-        cp -R hsa-amd-aqlprofile/opt/rocm-6.1.0/* $(Agent.BuildDirectory)/rocm
+        cp -R hsa-amd-aqlprofile/opt/rocm-6.2.0-14213/* $(Agent.BuildDirectory)/rocm
       workingDirectory: '$(Pipeline.Workspace)'
 # CI case: download latest default branch build
   - ${{ if eq(parameters.checkoutRef, '') }}:


### PR DESCRIPTION
Successful pipeline build with changes https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=2064&view=logs&j=4cbbbbe6-e3e9-50e2-34c4-5262ef5a7519

This is with latest amd-staging branch source of rocprofiler. In the future, we need to add some logic to pick up the latest .deb file from https://repo.radeon.com/rocm/misc/aqlprofile/ubuntu-22.04/ and to remove some of the hard-coded strings tied to version number in this yaml file.