### PR TITLE
Update what-is-rocm.rst

### DIFF
--- a/docs/what-is-rocm.rst
+++ b/docs/what-is-rocm.rst
@@ -121,7 +121,7 @@ Compilers
 
   "`FLANG <https://github.com/ROCm/flang/>`_", "An out-of-tree Fortran compiler targeting LLVM"
   ":doc:`hipCC <hipcc:index>`", "Compiler driver utility that calls Clang or NVCC and passes the appropriate include and library options for the target compiler and HIP infrastructure"
-  "`LLVM (amdclang) <https://github.com/ROCm/llvm-project>`_ ", "Toolkit for the construction of highly optimized compilers, optimizers, and runtime environments"
+  "`LLVM (amdclang) <https://github.com/ROCm/llvm-project-docs>`_ ", "Toolkit for the construction of highly optimized compilers, optimizers, and runtime environments"
 
 Runtimes
 -----------------------------------------------


### PR DESCRIPTION
Replaced with the new link for LLVM - https://github.com/ROCm/llvm-project-docs