### PR TITLE
Fix card text color in index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,6 @@ Our documentation is organized into the following categories:
 :class-container: rocm-doc-grid
 
 :::{grid-item-card}
-:class-card: sd-text-black
 :img-top: ./data/banner-installation.jpg
 :img-alt: Install documentation
 :padding: 2
@@ -46,7 +45,6 @@ Our documentation is organized into the following categories:
 :::
 
 :::{grid-item-card}
-:class-card: sd-text-black
 :img-top: ./data/banner-compatibility.jpg
 :img-alt: Compatibility information
 :padding: 2
@@ -64,7 +62,6 @@ Our documentation is organized into the following categories:
 
 <!-- markdownlint-disable MD051 -->
 :::{grid-item-card}
-:class-card: sd-text-black
 :img-top: ./data/banner-reference.jpg
 :img-alt: Reference documentation
 :padding: 2
@@ -85,7 +82,6 @@ Our documentation is organized into the following categories:
 <!-- markdownlint-enable MD051 -->
 
 :::{grid-item-card}
-:class-card: sd-text-black
 :img-top: ./data/banner-howto.jpg
 :img-alt: How-to documentation
 :padding: 2
@@ -108,7 +104,6 @@ Our documentation is organized into the following categories:
 :::
 
 :::{grid-item-card}
-:class-card: sd-text-black
 :img-top: ./data/banner-conceptual.jpg
 :img-alt: Conceptual documentation
 :padding: 2


### PR DESCRIPTION
This PR removes unnecessary the `sd-text-black` class from cards on the home page.
- This lets the text colour in those cards switch between black and white in light mode and dark mode, respectively.