### PR TITLE
Update single-gpu-fine-tuning-and-inference.rst with correct `amd-smi` flag

### DIFF
--- a/docs/how-to/llm-fine-tuning-optimization/single-gpu-fine-tuning-and-inference.rst
+++ b/docs/how-to/llm-fine-tuning-optimization/single-gpu-fine-tuning-and-inference.rst
@@ -45,7 +45,7 @@ Setting up the base implementation environment
 
    .. code-block:: shell
 
-      rocm-smi -showproductname
+      rocm-smi --showproductname
 
    Your output should look like this:
 


### PR DESCRIPTION
Updated to correctly use the `--showproductname` flag.

Prior flag of `-showproductname` was not valid.