### PR TITLE
External CI: Add all current component pipeline IDs

### DIFF
--- a/.azuredevops/templates/steps/artifact-download.yml
+++ b/.azuredevops/templates/steps/artifact-download.yml
@@ -9,43 +9,63 @@ parameters:
 - name: useDefaultBranch
   type: boolean
   default: true
+- name: extractToMnt
+  type: boolean
+  default: false
 - name: defaultBranchList
   type: object
   default:
-    amdsmi: develop
-    aomp: aomp-dev
-    aomp-extras: aomp-dev
     AMDMIGraphX: develop
+    amdsmi: develop
+    aomp-extras: aomp-dev
+    aomp: aomp-dev
     clr: develop
     composable_kernel: develop
     half: master
     HIP: develop
     hipBLAS: develop
+    hipBLASLt: develop
     hipCUB: develop
+    hipFFT: develop
+    hipfort: develop
+    HIPIFY: amd-staging
     hipRAND: develop
     hipSOLVER: develop
     hipSPARSE: develop
+    hipSPARSELt: develop
+    hipTensor: develop
     llvm-project: amd-staging
     MIOpen: develop
     MIVisionX: develop
+    rccl: develop
     rdc: develop
+    rocAL: develop
+    rocALUTION: develop
     rocBLAS: develop
     ROCdbgapi : amd-master
     rocDecode: develop
     rocFFT: develop
+    rocgdb: amd-staging
     rocm-cmake: develop
-    rocm_smi_lib: develop
-    rocminfo: master
+    rocm-core: master
+    rocm-examples: develop
+    rocminfo: amd-staging
     rocMLIR: develop
+    ROCmValidationSuite: master
+    rocm_bandwidth_test: master
+    rocm_smi_lib: develop
     rocPRIM: develop
     rocprofiler-register: amd-mainline
+    rocprofiler: amd-master
     ROCR-Runtime: master
     rocRAND: develop
+    rocr_debug_agent: amd-staging
     rocSOLVER: develop
     rocSPARSE: develop
     ROCT-Thunk-Interface: master
     rocThrust: develop
     roctracer: amd-master
+    rocWMMA: develop
     rpp: master
 - name: componentsFailureOkay
   type: object
@@ -75,7 +95,10 @@ steps:
   displayName: Extract ${{ parameters.componentName }}
   inputs:
     archiveFilePatterns: '$(Pipeline.Workspace)/d/**/*.tar.gz'
-    destinationFolder: '$(Agent.BuildDirectory)/rocm'
+    ${{ if parameters.extractToMnt }}:
+      destinationFolder: '/mnt/rocm'
+    ${{ else }}:
+      destinationFolder: '$(Agent.BuildDirectory)/rocm'
     cleanDestinationFolder: false
     overwriteExistingFiles: true
 - task: DeleteFiles@1

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -11,6 +11,9 @@ parameters:
     - staging
     - tag-builds
     - fixed
+- name: extractToMnt
+  type: boolean
+  default: false
 # required values for fixed selection
 - name: fixedPipelineIdentifier
   type: string
@@ -23,87 +26,119 @@ parameters:
 - name: stagingPipelineIdentifiers
   type: object
   default:
-    amdsmi: $(amdsmi-pipeline-id)
-    aomp: $(aomp-pipeline-id)
-    aomp-extras: $(aomp-extras-pipeline-id)
     AMDMIGraphX: $(amdmigraphx-pipeline-id)
+    amdsmi: $(amdsmi-pipeline-id)
+    aomp-extras: $(aomp-extras-pipeline-id)
+    aomp: $(aomp-pipeline-id)
     clr: $(clr-pipeline-id)
     composable_kernel: $(composable-kernel-pipeline-id)
     half: $(half-pipeline-id)
+    HIP: $(hip-pipeline-id)
     hipBLAS: $(hipblas-pipeline-id)
+    hipBLASLt: $(hipblaslt-pipeline-id)
     hipCUB: $(hipcub-pipeline-id)
+    hipFFT: $(hipfft-pipeline-id)
+    hipfort: $(hipfort-pipeline-id)
     HIPIFY: $(hipify-pipeline-id)
     hipRAND: $(hiprand-pipeline-id)
     hipSOLVER: $(hipsolver-pipeline-id)
     hipSPARSE: $(hipsparse-pipeline-id)
+    hipSPARSELt: $(hipsparselt-pipeline-id)
+    hipTensor: $(hiptensor-pipeline-id)
     llvm-project: $(llvm-project-pipeline-id)
     MIOpen: $(miopen-pipeline-id)
     MIVisionX: $(mivisionx-pipeline-id)
+    rccl: $(rccl-pipeline-id)
     rdc: $(rdc-pipeline-id)
+    rocAL: $(rocal-pipeline-id)
+    rocALUTION: $(rocalution-pipeline-id)
     rocBLAS: $(rocblas-pipeline-id)
     ROCdbgapi : $(rocdbgapi-pipeline-id)
     rocDecode: $(rocdecode-pipeline-id)
     rocFFT: $(rocfft-pipeline-id)
+    ROCgdb: $(rocgdb-pipeline-id)
     rocm-cmake: $(rocm-cmake-pipeline-id)
     rocm-core: $(rocm-core-pipeline-id)
-    rocm_smi_lib: $(rocm-smi-lib-pipeline-id)
+    rocm-examples: $(rocm-examples-pipeline-id)
     rocminfo: $(rocminfo-pipeline-id)
     rocMLIR: $(rocmlir-pipeline-id)
+    ROCmValidationSuite: $(rocmvalidationsuite-pipeline-id)
+    rocm_bandwidth_test: $(rocm-bandwidth-test-pipeline-id)
+    rocm_smi_lib: $(rocm-smi-lib-pipeline-id)
     rocPRIM: $(rocprim-pipeline-id)
     rocprofiler-register: $(rocprofiler-register-pipeline-id)
+    rocprofiler: $(rocprofiler-pipeline-id)
     ROCR-Runtime: $(rocr-runtime-pipeline-id)
     rocRAND: $(rocrand-pipeline-id)
+    rocr_debug_agent: $(rocr-debug-agent-pipeline-id)
     rocSOLVER: $(rocsolver-pipeline-id)
     rocSPARSE: $(rocsparse-pipeline-id)
     ROCT-Thunk-Interface: $(roct-thunk-interface-pipeline-id)
     rocThrust: $(rocthrust-pipeline-id)
     roctracer: $(roctracer-pipeline-id)
+    rocWMMA: $(rocwmma-pipeline-id)
     rpp: $(rpp-pipeline-id)
 - name: taggedPipelineIdentifiers
   type: object
   default:
-    amdsmi: $(amdsmi-tagged-pipeline-id)
-    aomp: $(aomp-tagged-pipeline-id)
-    aomp-extras: $(aomp-extras-tagged-pipeline-id)
     AMDMIGraphX: $(amdmigraphx-tagged-pipeline-id)
+    amdsmi: $(amdsmi-tagged-pipeline-id)
+    aomp-extras: $(aomp-extras-tagged-pipeline-id)
+    aomp: $(aomp-tagged-pipeline-id)
     clr: $(clr-tagged-pipeline-id)
     composable_kernel: $(composable-kernel-tagged-pipeline-id)
     half: $(half-tagged-pipeline-id)
+    HIP: $(hip-tagged-pipeline-id)
     hipBLAS: $(hipblas-tagged-pipeline-id)
+    hipBLASLt: $(hipblaslt-tagged-pipeline-id)
     hipCUB: $(hipcub-tagged-pipeline-id)
+    hipFFT: $(hipfft-tagged-pipeline-id)
+    hipfort: $(hipfort-tagged-pipeline-id)
     HIPIFY: $(hipify-tagged-pipeline-id)
     hipRAND: $(hiprand-tagged-pipeline-id)
     hipSOLVER: $(hipsolver-tagged-pipeline-id)
     hipSPARSE: $(hipsparse-tagged-pipeline-id)
+    hipSPARSELt: $(hipsparselt-tagged-pipeline-id)
+    hipTensor: $(hiptensor-tagged-pipeline-id)
     llvm-project: $(llvm-project-tagged-pipeline-id)
     MIOpen: $(miopen-tagged-pipeline-id)
     MIVisionX: $(mivisionx-tagged-pipeline-id)
+    rccl: $(rccl-tagged-pipeline-id)
     rdc: $(rdc-tagged-pipeline-id)
+    rocAL: $(rocal-tagged-pipeline-id)
+    rocALUTION: $(rocalution-tagged-pipeline-id)
     rocBLAS: $(rocblas-tagged-pipeline-id)
     ROCdbgapi : $(rocdbgapi-tagged-pipeline-id)
     rocDecode: $(rocdecode-tagged-pipeline-id)
     rocFFT: $(rocfft-tagged-pipeline-id)
+    ROCgdb: $(rocgdb-tagged-pipeline-id)
     rocm-cmake: $(rocm-cmake-tagged-pipeline-id)
     rocm-core: $(rocm-core-tagged-pipeline-id)
-    rocm_smi_lib: $(rocm-smi-lib-tagged-pipeline-id)
+    rocm-examples: $(rocm-examples-tagged-pipeline-id)
     rocminfo: $(rocminfo-tagged-pipeline-id)
     rocMLIR: $(rocmlir-tagged-pipeline-id)
+    ROCmValidationSuite: $(rocmvalidationsuite-tagged-pipeline-id)
+    rocm_bandwidth_test: $(rocm-bandwidth-test-tagged-pipeline-id)
+    rocm_smi_lib: $(rocm-smi-lib-tagged-pipeline-id)
     rocPRIM: $(rocprim-tagged-pipeline-id)
     rocprofiler-register: $(rocprofiler-register-tagged-pipeline-id)
+    rocprofiler: $(rocprofiler-tagged-pipeline-id)
     ROCR-Runtime: $(rocr-runtime-tagged-pipeline-id)
     rocRAND: $(rocrand-tagged-pipeline-id)
+    rocr_debug_agent: $(rocr-debug-agent-tagged-pipeline-id)
     rocSOLVER: $(rocsolver-tagged-pipeline-id)
     rocSPARSE: $(rocsparse-tagged-pipeline-id)
     ROCT-Thunk-Interface: $(roct-thunk-interface-tagged-pipeline-id)
     rocThrust: $(rocthrust-tagged-pipeline-id)
     roctracer: $(roctracer-tagged-pipeline-id)
+    rocWMMA: $(rocwmma-tagged-pipeline-id)
     rpp: $(rpp-tagged-pipeline-id)
 # set to true if you're calling this template file multiple files in same pipeline
 # only leave last call false to optimize sequence
 - name: skipLibraryLinking
   type: boolean
   default: false
-
+  
 steps:
 # assuming artifact-download.yml template file in same directory
 - ${{ each dependency in parameters.dependencyList }}:
@@ -112,31 +147,45 @@ steps:
       parameters:
         componentName: ${{ dependency }}
         pipelineId: ${{ parameters.stagingPipelineIdentifiers[dependency] }}
+        extractToMnt: ${{ parameters.extractToMnt }}
   - ${{ if eq(parameters.dependencySource, 'tag-builds') }}:
     - template: artifact-download.yml
       parameters:
         componentName: ${{ dependency }}
         pipelineId: ${{ parameters.taggedPipelineIdentifiers[dependency] }}
+        extractToMnt: ${{ parameters.extractToMnt }}
 # fixed case only accepts one component at a time, so no array input
 - ${{ if eq(parameters.dependencySource, 'fixed') }}:
   - template: artifact-download.yml
     parameters:
       componentName: ${{ parameters.fixedComponentName }}
       pipelineId: ${{ parameters.fixedPipelineIdentifier }}
+      extractToMnt: ${{ parameters.extractToMnt }}
 - task: Bash@3
   displayName: 'list downloaded ROCm files'
   inputs:
     targetType: inline
-    script: ls -1R $(Agent.BuildDirectory)/rocm
+    ${{ if eq(parameters.extractToMnt, true) }}:
+      script: ls -1R /mnt/rocm
+    ${{ else }}:
+      script: ls -1R $(Agent.BuildDirectory)/rocm
 - ${{ if eq(parameters.skipLibraryLinking, false) }}:
   - task: Bash@3
     displayName: 'link ROCm shared libraries'
     inputs:
       targetType: inline
 # OS ignores if the ROCm lib folder shows up more than once
-      script: |
-        echo $(Agent.BuildDirectory)/rocm/lib | sudo tee -a /etc/ld.so.conf
-        echo $(Agent.BuildDirectory)/rocm/llvm/lib | sudo tee -a /etc/ld.so.conf
-        sudo cat /etc/ld.so.conf
-        sudo ldconfig -v
-        ldconfig -p
+      ${{ if eq(parameters.extractToMnt, true) }}:
+        script: |
+          echo /mnt/rocm/lib | sudo tee -a /etc/ld.so.conf
+          echo /mnt/rocm/llvm/lib | sudo tee -a /etc/ld.so.conf
+          sudo cat /etc/ld.so.conf
+          sudo ldconfig -v
+          ldconfig -p
+      ${{ else }}:
+        script: |
+          echo $(Agent.BuildDirectory)/rocm/lib | sudo tee -a /etc/ld.so.conf
+          echo $(Agent.BuildDirectory)/rocm/llvm/lib | sudo tee -a /etc/ld.so.conf
+          sudo cat /etc/ld.so.conf
+          sudo ldconfig -v
+          ldconfig -p

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -138,7 +138,7 @@ parameters:
 - name: skipLibraryLinking
   type: boolean
   default: false
-  
+
 steps:
 # assuming artifact-download.yml template file in same directory
 - ${{ each dependency in parameters.dependencyList }}:


### PR DESCRIPTION
Adds all externally building ROCm component pipelines and their Azure IDs. Also includes support for extracting components into Azure ephemeral storage at `/mnt` instead of `Agent.BuildDirectory`
Cherry picked from nightly branch so other components can start using these pipelines.