### PR TITLE
External CI: build hipBLASLt external dependencies

### DIFF
--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -74,7 +74,11 @@ jobs:
   - script: sudo ln -s $(Agent.BuildDirectory)/rocm /opt/rocm
     displayName: ROCm symbolic link
 # Build and install gtest, lapack, hipBLAS-common
+# $(Pipeline.Workspace)/deps is a temporary folder for the build process
+# $(Pipeline.Workspace)/s/deps is part of the hipBLASLt repo
   - script: mkdir $(Pipeline.Workspace)/deps
+# hipBLASLt already has a CMake script for external deps, so we can just run that
+# https://github.com/ROCm/hipBLASLt/blob/develop/deps/CMakeLists.txt
   - script: cmake $(Pipeline.Workspace)/s/deps
     displayName: Configure hipBLASLt external dependencies
     workingDirectory: $(Pipeline.Workspace)/deps

--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -60,7 +60,7 @@ jobs:
     parameters:
       checkoutRepo: ${{ parameters.checkoutRepo }}
 # CI case: download latest default branch build
-  - ${{ if eq(parameters.checkoutRef, '--build') }}:
+  - ${{ if eq(parameters.checkoutRef, '') }}:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         dependencyList: ${{ parameters.rocmDependencies }}

--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -8,12 +8,13 @@ parameters:
 - name: aptPackages
   type: object
   default:
-    - ninja-build
-    - python3-venv
-    - libmsgpack-dev
+    - gfortran
     - git
-    - python3-pip
     - libdrm-dev
+    - libmsgpack-dev
+    - ninja-build
+    - python3-pip
+    - python3-venv
 - name: pipModules
   type: object
   default:
@@ -21,12 +22,12 @@ parameters:
 - name: rocmDependencies
   type: object
   default:
-    - llvm-project
-    - ROCR-Runtime
     - clr
+    - hipBLAS
+    - llvm-project
     - rocminfo
     - rocprofiler-register
-    - hipBLAS
+    - ROCR-Runtime
 
 jobs:
 - job: hipBLASLt
@@ -58,8 +59,8 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
     parameters:
       checkoutRepo: ${{ parameters.checkoutRepo }}
-  # CI case: download latest default branch build
-  - ${{ if eq(parameters.checkoutRef, '') }}:
+# CI case: download latest default branch build
+  - ${{ if eq(parameters.checkoutRef, '--build') }}:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         dependencyList: ${{ parameters.rocmDependencies }}
@@ -72,6 +73,23 @@ jobs:
         dependencySource: tag-builds
   - script: sudo ln -s $(Agent.BuildDirectory)/rocm /opt/rocm
     displayName: ROCm symbolic link
+# Build and install gtest, lapack, hipBLAS-common
+  - script: mkdir $(Pipeline.Workspace)/deps
+  - script: cmake $(Pipeline.Workspace)/s/deps
+    displayName: Configure hipBLASLt external dependencies
+    workingDirectory: $(Pipeline.Workspace)/deps
+  - script: make
+    displayName: Build hipBLASLt external dependencies
+    workingDirectory: $(Pipeline.Workspace)/deps
+  - script: sudo make install
+    displayName: Install hipBLASLt external dependencies
+    workingDirectory: $(Pipeline.Workspace)/deps
+# Set link to redirect llvm folder
+  - task: Bash@3
+    displayName: Symlink to rocm/lib/llvm
+    inputs:
+      targetType: inline
+      script: ln -s $(Agent.BuildDirectory)/rocm/llvm $(Agent.BuildDirectory)/rocm/lib/llvm
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
     parameters:
       extraBuildFlags: >-


### PR DESCRIPTION
Build and install gtest, lapack, and hipBLAS-common for hipBLASLt pipeline.

hipBLAS-common is a new repo for code used for both hipBLAS and hipBLASLt. hipBLAS doesn't seem to actually pull in hipBLAS-common just yet, so this PR only includes hipBLASLt. Also, we may want to create a separate pipeline for hipBLAS-common in the future.
https://github.com/ROCm/hipBLAS-common

Successful build: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=3214&view=results

