### PR TITLE
External CI: Increase composable_kernel pipeline time limit

### DIFF
--- a/.azuredevops/components/composable_kernel.yml
+++ b/.azuredevops/components/composable_kernel.yml
@@ -25,7 +25,7 @@ parameters:
 
 jobs:
 - job: composable_kernel
-  timeoutInMinutes: 210
+  timeoutInMinutes: 300
   variables:
   - group: common
   - template: /.azuredevops/variables-global.yml


### PR DESCRIPTION
CK build count increased from 700 to 827. Increasing the time limit accordingly