### PR TITLE
External CI: ROCm nightly builds

### DIFF
--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -61,8 +61,7 @@ schedules:
   displayName: Nightly build
   branches:
     include:
-    # - develop
-    - amd/danielsu/rocm-nightly
+    - develop
   always: true
 
 jobs:

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -1,0 +1,116 @@
+parameters:
+# currently excludes clr and rocm-examples
+- name: rocmDependencies
+  type: object
+  default:
+    - AMDMIGraphX
+    - amdsmi
+    - aomp-extras
+    - aomp
+    - composable_kernel
+    - half
+    - HIP
+    - hipBLAS
+    - hipBLASLt
+    - hipCUB
+    - hipFFT
+    - hipfort
+    - HIPIFY
+    - hipRAND
+    - hipSOLVER
+    - hipSPARSE
+    - hipSPARSELt
+    - hipTensor
+    - llvm-project
+    - MIOpen
+    - MIVisionX
+    - rccl
+    - rdc
+    - rocAL
+    - rocALUTION
+    - rocBLAS
+    - ROCdbgapi
+    - rocDecode
+    - rocFFT
+    - ROCgdb
+    - rocm-cmake
+    - rocm-core
+    - rocminfo
+    - rocMLIR
+    - ROCmValidationSuite
+    - rocm_bandwidth_test
+    - rocm_smi_lib
+    - rocPRIM
+    - rocprofiler-register
+    - rocprofiler
+    - ROCR-Runtime
+    - rocRAND
+    - rocr_debug_agent
+    - rocSOLVER
+    - rocSPARSE
+    - ROCT-Thunk-Interface
+    - rocThrust
+    - roctracer
+    - rocWMMA
+    - rpp
+
+trigger: none
+pr: none
+schedules:
+- cron: '30 7 * * *'
+  displayName: Nightly build
+  branches:
+    include:
+    # - develop
+    - amd/danielsu/rocm-nightly
+  always: true
+
+jobs:
+- job: rocm_nightly
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool: ${{ variables.MEDIUM_BUILD_POOL }}
+  workspace:
+    clean: all
+  steps:
+  - task: DeleteFiles@1
+    displayName: 'Cleanup checkout space'
+    inputs:
+      SourceFolder: '$(Agent.BuildDirectory)/s'
+      Contents: '**/*'
+  - task: DeleteFiles@1
+    displayName: 'Cleanup Staging Area'
+    inputs:
+      SourceFolder: '$(Build.ArtifactStagingDirectory)'
+      Contents: '/**/*'
+      RemoveDotFiles: true
+  - script: sudo chmod 777 /mnt
+    displayName: 'Set permissions for /mnt'
+  - script: df -h
+    displayName: System disk space before ROCm
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
+    parameters:
+      dependencyList: ${{ parameters.rocmDependencies }}
+      dependencySource: staging
+      extractToMnt: true
+      skipLibraryLinking: true
+  - script: df -h
+    displayName: System disk space after ROCm
+  - script: du -sh /mnt/rocm
+    displayName: Uncompressed ROCm size
+  - task: ArchiveFiles@2
+    displayName: Compress rocm-nightly
+    inputs:
+      rootFolderOrFile: /mnt/rocm
+      includeRootFolder: false
+      archiveType: tar
+      tarCompression: gz
+      archiveFile: $(Build.ArtifactStagingDirectory)/$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204.tar.gz
+  - script: du -sh $(Build.ArtifactStagingDirectory)
+    displayName: Compressed ROCm size
+  - task: PublishPipelineArtifact@1
+    displayName: 'Public ROCm Nightly Artifact'
+    retryCountOnTaskFailure: 3
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
This job collects the latest builds from all component pipelines and packages them into a single tarball. It runs daily at 07:30 UTC (03:30 EDT). 

Previous test runs: https://dev.azure.com/ROCm-CI/ROCm-CI/_build?definitionId=152