### PR TITLE
External CI: move hipBLASLt to new large disk pool

### DIFF
--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -40,7 +40,7 @@ jobs:
   variables:
   - group: common
   - template: /.azuredevops/variables-global.yml
-  pool: ${{ variables.MEDIUM_BUILD_POOL }}
+  pool: ${{ variables.LARGE_DISK_BUILD_POOL }}
   workspace:
     clean: all
   steps:

--- a/.azuredevops/variables-global.yml
+++ b/.azuredevops/variables-global.yml
@@ -21,6 +21,8 @@ variables:
   value: rocm-ci_ultra_build_pool
 - name: ON_PREM_BUILD_POOL
   value: rocm-ci_build_pool
+- name: LARGE_DISK_BUILD_POOL
+  value: rocm-ci_larger_base_disk_pool
 - name: LATEST_RELEASE_TAG
   value: rocm-6.1.0
 - name: DOCKER_IMAGE_NAME


### PR DESCRIPTION
Creates a variable for a new medium build pool with 2 TB OS disks and sets hipBLASLt to use it. Going forward, this should be the preferred way to resolve pipeline storage issues.

Successful build: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=3746&view=results