### PR TITLE
External CI: add libdrm-dev package to rocFFT

### DIFF
--- a/.azuredevops/components/rocFFT.yml
+++ b/.azuredevops/components/rocFFT.yml
@@ -11,6 +11,7 @@ parameters:
     - cmake
     - ninja-build
     - libboost-program-options-dev
+    - libdrm-dev
     - libgtest-dev
     - libfftw3-dev
     - python3-pip


### PR DESCRIPTION
Fixes build failures caused by missing shared library `libdrm_amdgpu.so`

Successful build: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=4318&view=results