### PR TITLE
External CI: Parallel per GPU jobs and file filters

### DIFF
--- a/.azuredevops/components/roctracer.yml
+++ b/.azuredevops/components/roctracer.yml
@@ -37,6 +37,12 @@ jobs:
     vmImage: ${{ variables.BASE_BUILD_POOL }}
   workspace:
     clean: all
+  strategy:
+    matrix:
+      gfx942:
+        JOB_GPU_TARGET: gfx942
+      gfx90a:
+        JOB_GPU_TARGET: gfx90a
   steps:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
     parameters:
@@ -65,6 +71,8 @@ jobs:
         -DROCM_PATH=$(Agent.BuildDirectory)/rocm
         -DCMAKE_MODULE_PATH=$(Agent.BuildDirectory)/rocm/lib/cmake/hip
         -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
-        -DGPU_TARGETS=gfx942
+        -DGPU_TARGETS=$(JOB_GPU_TARGET)
         -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
+    parameters:
+      gpuTarget: $(JOB_GPU_TARGET)

--- a/.azuredevops/templates/steps/artifact-download.yml
+++ b/.azuredevops/templates/steps/artifact-download.yml
@@ -15,6 +15,9 @@ parameters:
 - name: extractToMnt
   type: boolean
   default: false
+- name: fileFilter
+  type: string
+  default: ''
 - name: defaultBranchList
   type: object
   default:
@@ -83,6 +86,7 @@ steps:
     project: ROCm-CI
     definition: ${{ parameters.pipelineId }}
     specificBuildWithTriggering: true
+    itemPattern: '**/*${{ parameters.fileFilter }}*'
     ${{ if eq(parameters.latestFromBranch, true) }}:
       ${{ if notIn(parameters.componentName, 'aomp', 'clr', 'rocMLIR') }}: # remove this once these pipelines are functional + up-to-date
         buildVersionToDownload: latestFromBranch # default is 'latest'

--- a/.azuredevops/templates/steps/artifact-upload.yml
+++ b/.azuredevops/templates/steps/artifact-upload.yml
@@ -9,6 +9,9 @@ parameters:
 - name: publish
   type: boolean
   default: true
+- name: gpuTarget
+  type: string
+  default: ''
 
 steps:
 - task: ArchiveFiles@2
@@ -17,7 +20,7 @@ steps:
     includeRootFolder: false
     archiveType: 'tar'
     tarCompression: 'gz'
-    archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.DefinitionName)_$(Build.SourceBranchName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_${{ parameters.artifactName }}.tar.gz'
+    archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.DefinitionName)_$(Build.SourceBranchName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_${{ parameters.artifactName }}_${{ parameters.gpuTarget }}.tar.gz'
 - task: DeleteFiles@1
   displayName: 'Cleanup Staging Area'
   inputs:

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -144,21 +144,44 @@ parameters:
 
 steps:
 # assuming artifact-download.yml template file in same directory
+# for the case where rocm dependency item in list has a colon (:)
+# assume it is of the format of componentName:fileFilter
+# fileFilter could contain both a subcomponent name or gpu name separated by asterisks
+# e.g., gfx942 to only download artifacts from component for this gpu if applicable
 - ${{ each dependency in parameters.dependencyList }}:
-  - ${{ if eq(parameters.dependencySource, 'staging') }}:
-    - template: artifact-download.yml
-      parameters:
-        componentName: ${{ dependency }}
-        pipelineId: ${{ parameters.stagingPipelineIdentifiers[dependency] }}
-        latestFromBranch: ${{ parameters.latestFromBranch }}
-        extractToMnt: ${{ parameters.extractToMnt }}
-  - ${{ if eq(parameters.dependencySource, 'tag-builds') }}:
-    - template: artifact-download.yml
-      parameters:
-        componentName: ${{ dependency }}
-        pipelineId: ${{ parameters.taggedPipelineIdentifiers[dependency] }}
-        latestFromBranch: ${{ parameters.latestFromBranch }}
-        extractToMnt: ${{ parameters.extractToMnt }}
+  - ${{ if contains(dependency, ':') }}:
+    - ${{ if eq(parameters.dependencySource, 'staging') }}:
+      - template: artifact-download.yml
+        parameters:
+          componentName: ${{ split(dependency, ':')[0] }}
+          pipelineId: ${{ parameters.stagingPipelineIdentifiers[split(dependency, ':')[0]] }}
+          fileFilter: ${{ split(dependency, ':')[1] }}
+          latestFromBranch: ${{ parameters.latestFromBranch }}
+          extractToMnt: ${{ parameters.extractToMnt }}
+    - ${{ if eq(parameters.dependencySource, 'tag-builds') }}:
+      - template: artifact-download.yml
+        parameters:
+          componentName: ${{ split(dependency, ':')[0] }}
+          pipelineId: ${{ parameters.taggedPipelineIdentifiers[split(dependency, ':')[0]] }}
+          fileFilter: ${{ split(dependency, ':')[1] }}
+          latestFromBranch: ${{ parameters.latestFromBranch }}
+          extractToMnt: ${{ parameters.extractToMnt }}
+# no colon (:) found in this item in the list
+  - ${{ else }}:
+    - ${{ if eq(parameters.dependencySource, 'staging') }}:
+      - template: artifact-download.yml
+        parameters:
+          componentName: ${{ dependency }}
+          pipelineId: ${{ parameters.stagingPipelineIdentifiers[dependency] }}
+          latestFromBranch: ${{ parameters.latestFromBranch }}
+          extractToMnt: ${{ parameters.extractToMnt }}
+    - ${{ if eq(parameters.dependencySource, 'tag-builds') }}:
+      - template: artifact-download.yml
+        parameters:
+          componentName: ${{ dependency }}
+          pipelineId: ${{ parameters.taggedPipelineIdentifiers[dependency] }}
+          latestFromBranch: ${{ parameters.latestFromBranch }}
+          extractToMnt: ${{ parameters.extractToMnt }}
 # fixed case only accepts one component at a time, so no array input
 - ${{ if eq(parameters.dependencySource, 'fixed') }}:
   - template: artifact-download.yml


### PR DESCRIPTION
Adding support for parallel build jobs where the only difference is the singular GPU target. This allows nightly packaging jobs to pick and choose based on GPU target to reduce download size.

To accommodate this new feature producing multiple artifacts for a component, added support for a file filter when downloading a ROCm component using the format "componentName:fileFilter".

Sample build log: https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=4897&view=logs&j=aace0673-15c3-5d68-a50e-725354a1b253
Note that llvm-project is specified with filter amd-staging (i.e., llvm-project:amd-staging in the ROCm dependency array) to test out the file filter when set and the other components do not set a file filter to test base case.