### PR TITLE
External CI: Nightly pytorch packaging

### DIFF
--- a/.azuredevops/nightly/pytorch.yml
+++ b/.azuredevops/nightly/pytorch.yml
@@ -245,8 +245,8 @@ jobs:
         DESIRED_DEVTOOLSET=$(DESIRED_DEVTOOLSET)
         bash ./manywheel/build_rocm.sh
       workingDirectory: $(Build.SourcesDirectory)/builder
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-prepare-package.yml
-    parameters:
-      sourceDir: /remote
-      contentsString: 'wheelhouserocm*/torch*.whl'
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
+  - task: PublishPipelineArtifact@1
+    displayName: 'ROCm pytorch wheel file Publish'
+    retryCountOnTaskFailure: 3
+    inputs:
+      targetPath: /remote/wheelhouserocm$(ROCM_VERSION)


### PR DESCRIPTION
Skip redundant step of compressing wheel file into a tarball and publish the wheel file explicitly.

Build log with test run: https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=4898&view=logs&j=970c8651-ba54-51fd-dcbf-513da2c9c2ce