### PR TITLE
Fix intersphinx links

### DIFF
--- a/docs/compatibility/compatibility-matrix.rst
+++ b/docs/compatibility/compatibility-matrix.rst
@@ -38,9 +38,9 @@ You can also refer to the :ref:`past versions of ROCm compatibility matrix<past-
       ,gfx908,gfx908,gfx908
       ,,,
       FRAMEWORK SUPPORT,".. _framework-support-compatibility-matrix:",,
-      :doc:`PyTorch <rocm-install-on-linux:how-to/3rd-party/pytorch-install>`,"2.3, 2.2, 2.1, 2.0, 1.13","2.1, 2.0, 1.13","2.1, 2.0, 1.13"
-      :doc:`TensorFlow <rocm-install-on-linux:how-to/3rd-party/tensorflow-install>`,"2.16.1, 2.15.1, 2.14.1","2.15, 2.14, 2.13","2.14, 2.13, 2.12"
-      :doc:`JAX <rocm-install-on-linux:how-to/3rd-party/jax-install>`,0.4.26,0.4.26,0.4.26
+      :doc:`PyTorch <rocm-install-on-linux:install/3rd-party/pytorch-install>`,"2.3, 2.2, 2.1, 2.0, 1.13","2.1, 2.0, 1.13","2.1, 2.0, 1.13"
+      :doc:`TensorFlow <rocm-install-on-linux:install/3rd-party/tensorflow-install>`,"2.16.1, 2.15.1, 2.14.1","2.15, 2.14, 2.13","2.14, 2.13, 2.12"
+      :doc:`JAX <rocm-install-on-linux:install/3rd-party/jax-install>`,0.4.26,0.4.26,0.4.26
       `ONNX Runtime <https://onnxruntime.ai/docs/build/eps.html#amd-migraphx>`_,1.17.3,1.17.3,1.14.1
       ,,,
       THIRD PARTY COMMS,".. _thirdpartycomms-support-compatibility-matrix:",,

--- a/docs/conceptual/ai-pytorch-inception.md
+++ b/docs/conceptual/ai-pytorch-inception.md
@@ -65,7 +65,7 @@ This example is adapted from the PyTorch research hub page on [Inception V3](htt
 
 Follow these steps:
 
-1. Run the PyTorch ROCm-based Docker image or refer to the section {doc}`Installing PyTorch <rocm-install-on-linux:how-to/3rd-party/pytorch-install>` for setting up a PyTorch environment on ROCm.
+1. Run the PyTorch ROCm-based Docker image or refer to the section {doc}`Installing PyTorch <rocm-install-on-linux:install/3rd-party/pytorch-install>` for setting up a PyTorch environment on ROCm.
 
     ```dockerfile
     docker run -it -v $HOME:/data --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --device=/dev/kfd --device=/dev/dri --group-add video --ipc=host --shm-size 8G rocm/pytorch:latest
@@ -155,7 +155,7 @@ The previous section focused on downloading and using the Inception V3 model for
 
 Follow these steps:
 
-1. Run the PyTorch ROCm Docker image or refer to the section {doc}`Installing PyTorch <rocm-install-on-linux:how-to/3rd-party/pytorch-install>` for setting up a PyTorch environment on ROCm.
+1. Run the PyTorch ROCm Docker image or refer to the section {doc}`Installing PyTorch <rocm-install-on-linux:install/3rd-party/pytorch-install>` for setting up a PyTorch environment on ROCm.
 
     ```dockerfile
     docker pull rocm/pytorch:latest

--- a/docs/how-to/deep-learning-rocm.rst
+++ b/docs/how-to/deep-learning-rocm.rst
@@ -13,9 +13,9 @@ frameworks to ensure that framework-specific optimizations take advantage of AMD
 
 The following guides cover installation processes for ROCm-aware deep learning frameworks.
 
-* :doc:`PyTorch for ROCm <rocm-install-on-linux:how-to/3rd-party/pytorch-install>`
-* :doc:`TensorFlow for ROCm <rocm-install-on-linux:how-to/3rd-party/tensorflow-install>`
-* :doc:`JAX for ROCm <rocm-install-on-linux:how-to/3rd-party/jax-install>`
+* :doc:`PyTorch for ROCm <rocm-install-on-linux:install/3rd-party/pytorch-install>`
+* :doc:`TensorFlow for ROCm <rocm-install-on-linux:install/3rd-party/tensorflow-install>`
+* :doc:`JAX for ROCm <rocm-install-on-linux:install/3rd-party/jax-install>`
 
 The following chart steps through typical installation workflows for installing deep learning frameworks for ROCm.
 

--- a/docs/how-to/llm-fine-tuning-optimization/model-acceleration-libraries.rst
+++ b/docs/how-to/llm-fine-tuning-optimization/model-acceleration-libraries.rst
@@ -250,4 +250,4 @@ page describes the options.
    :align: center
 
 Learn more about optimizing kernels with TunableOp in
-:ref:`Optimizing Triton kernels <fine-tuning-llms-triton-tunableop>`.
+:ref:`Optimizing Triton kernels <mi300x-tunableop>`.

--- a/docs/how-to/llm-fine-tuning-optimization/multi-gpu-fine-tuning-and-inference.rst
+++ b/docs/how-to/llm-fine-tuning-optimization/multi-gpu-fine-tuning-and-inference.rst
@@ -37,7 +37,7 @@ Setting up the base implementation environment
 ----------------------------------------------
 
 #. Install PyTorch for ROCm. Refer to the
-   :doc:`PyTorch installation guide <rocm-install-on-linux:how-to/3rd-party/pytorch-install>`. For consistent
+   :doc:`PyTorch installation guide <rocm-install-on-linux:install/3rd-party/pytorch-install>`. For consistent
    installation, it’s recommended to use official ROCm prebuilt Docker images with the framework pre-installed.
 
 #. In the Docker container, check the availability of ROCM-capable accelerators using the following command.

--- a/docs/how-to/llm-fine-tuning-optimization/single-gpu-fine-tuning-and-inference.rst
+++ b/docs/how-to/llm-fine-tuning-optimization/single-gpu-fine-tuning-and-inference.rst
@@ -38,7 +38,7 @@ Setting up the base implementation environment
 ----------------------------------------------
 
 #. Install PyTorch for ROCm. Refer to the
-   :doc:`PyTorch installation guide <rocm-install-on-linux:how-to/3rd-party/pytorch-install>`. For a consistent
+   :doc:`PyTorch installation guide <rocm-install-on-linux:install/3rd-party/pytorch-install>`. For a consistent
    installation, it’s recommended to use official ROCm prebuilt Docker images with the framework pre-installed.
 
 #. In the Docker container, check the availability of ROCm-capable accelerators using the following command.

--- a/docs/how-to/rocm-for-ai/install.rst
+++ b/docs/how-to/rocm-for-ai/install.rst
@@ -16,10 +16,10 @@ Before getting started, install ROCm and supported machine learning frameworks.
 
       Each release of ROCm supports specific hardware and software configurations. Before installing, consult the
       :doc:`System requirements <rocm-install-on-linux:reference/system-requirements>` and
-      :doc:`Installation prerequisites <rocm-install-on-linux:how-to/prerequisites>` guides.
+      :doc:`Installation prerequisites <rocm-install-on-linux:install/prerequisites>` guides.
 
 If you’re new to ROCm, refer to the :doc:`ROCm quick start install guide for Linux
-<rocm-install-on-linux:tutorial/quick-start>`.
+<rocm-install-on-linux:install/quick-start>`.
 
 If you’re using a Radeon GPU for graphics-accelerated applications, refer to the
 :doc:`Radeon installation instructions <radeon:docs/install/install-radeon>`.

--- a/docs/how-to/rocm-for-ai/install.rst
+++ b/docs/how-to/rocm-for-ai/install.rst
@@ -53,8 +53,10 @@ ROCm supports popular machine learning frameworks and libraries including `PyTor
 Review the framework installation documentation. For ease-of-use, it's recommended to use official ROCm prebuilt Docker
 images with the framework pre-installed.
 
-* :doc:`PyTorch for ROCm <rocm-install-on-linux:how-to/3rd-party/pytorch-install>`
-* :doc:`TensorFlow for ROCm <rocm-install-on-linux:how-to/3rd-party/tensorflow-install>`
-* :doc:`JAX for ROCm <rocm-install-on-linux:how-to/3rd-party/jax-install>`
+* :doc:`PyTorch for ROCm <rocm-install-on-linux:install/3rd-party/pytorch-install>`
+
+* :doc:`TensorFlow for ROCm <rocm-install-on-linux:install/3rd-party/tensorflow-install>`
+
+* :doc:`JAX for ROCm <rocm-install-on-linux:install/3rd-party/jax-install>`
 
 The sections that follow in :doc:`Training a model <train-a-model>` are geared for a ROCm with PyTorch installation.

--- a/docs/how-to/system-optimization/mi300a.rst
+++ b/docs/how-to/system-optimization/mi300a.rst
@@ -215,7 +215,7 @@ System management
 For a complete guide on installing, managing, and uninstalling ROCm on Linux, see
 :doc:`Quick-start (Linux)<rocm-install-on-linux:tutorial/quick-start>`. To verify that the
 installation was successful, see the
-:doc:`Post-installation instructions<rocm-install-on-linux:how-to/native-install/post-install>` and 
+:doc:`Post-installation instructions<rocm-install-on-linux:install/native-install/post-install>` and 
 :doc:`ROCm tools <../../reference/rocm-tools>` guides. If verification
 fails, consult the :doc:`System debugging guide <../system-debugging>`.
 

--- a/docs/how-to/system-optimization/mi300x.rst
+++ b/docs/how-to/system-optimization/mi300x.rst
@@ -474,7 +474,7 @@ It is recommended to set the following environment variable:
    This is the default option as of ROCm 6.2.
 
 Change affinity of ROCm helper threads
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This change prevents internal ROCm threads from having their CPU core affinity mask 
 set to all CPU cores available. With this setting, the threads inherit their parent's 

--- a/docs/how-to/system-optimization/mi300x.rst
+++ b/docs/how-to/system-optimization/mi300x.rst
@@ -532,9 +532,9 @@ can provide system-level information, offering valuable insights for
 optimizing user applications.
 
 For a complete guide on how to install, manage, or uninstall ROCm on Linux, refer to
-:doc:`rocm-install-on-linux:tutorial/quick-start`. For verifying that the
+:doc:`rocm-install-on-linux:install/quick-start`. For verifying that the
 installation was successful, refer to the
-:doc:`rocm-install-on-linux:how-to/native-install/post-install`.
+:doc:`rocm-install-on-linux:install/native-install/post-install`.
 Should verification fail, consult :doc:`/how-to/system-debugging`.
 
 Hardware verification with ROCm

--- a/docs/how-to/system-optimization/w6000-v620.md
+++ b/docs/how-to/system-optimization/w6000-v620.md
@@ -12,7 +12,7 @@
 This chapter reviews system settings that are required to configure the system
 for ROCm virtualization on RDNA2-based AMD Radeon™ PRO GPUs. Installing ROCm on
 Bare Metal follows the routine ROCm
-{doc}`installation procedure<rocm-install-on-linux:how-to/native-install/index>`.
+{doc}`installation procedure<rocm-install-on-linux:install/native-install/index>`.
 
 To enable ROCm virtualization on V620, one has to setup Single Root I/O
 Virtualization (SR-IOV) in the BIOS via setting found in the following
@@ -166,4 +166,4 @@ First, assign GPU virtual function (VF) to VM using the following steps.
 Then start the VM.
 
 Finally install ROCm on the virtual machine (VM). For detailed instructions,
-refer to the {doc}`Linux install guide<rocm-install-on-linux:how-to/native-install/index>`.
+refer to the {doc}`Linux install guide<rocm-install-on-linux:install/native-install/index>`.


### PR DESCRIPTION
Intersphinx links need to be updated due to https://github.com/ROCm/rocm-install-on-linux/pull/169/files#diff-45ae04487cf5c756c45df6508ae24d237c8f2cde0ec78079b5e2c4eaab2d8fae