### PR TITLE
External CI: fix ROCgdb component name

### DIFF
--- a/.azuredevops/templates/steps/artifact-download.yml
+++ b/.azuredevops/templates/steps/artifact-download.yml
@@ -51,7 +51,7 @@ parameters:
     ROCdbgapi : amd-staging
     rocDecode: develop
     rocFFT: develop
-    rocgdb: amd-staging
+    ROCgdb: amd-staging
     rocm-cmake: develop
     rocm-core: master
     rocm-examples: develop


### PR DESCRIPTION
Corrects the capitalization for ROCgdb, should be the last typo we have in the default branch list.

Successful nightly build, all components are found and downloaded:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=4946&view=results