### PR TITLE
External CI: Adjustments from per-GPU job deployment.

### DIFF
--- a/.azuredevops/components/composable_kernel.yml
+++ b/.azuredevops/components/composable_kernel.yml
@@ -25,7 +25,7 @@ parameters:
 
 jobs:
 - job: composable_kernel
-  timeoutInMinutes: 100
+  timeoutInMinutes: 120
   variables:
   - group: common
   - template: /.azuredevops/variables-global.yml

--- a/.azuredevops/components/hipSPARSELt.yml
+++ b/.azuredevops/components/hipSPARSELt.yml
@@ -51,8 +51,6 @@ jobs:
     matrix:
       gfx942:
         JOB_GPU_TARGET: gfx942
-      gfx90a:
-        JOB_GPU_TARGET: gfx90a
   steps:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
     parameters:


### PR DESCRIPTION
hipSPARSELt does not support gfx90a according to its CMakeLists.txt composable_kernel build jobs are timing out, so adding 20 minutes more.