### PR TITLE
Revert "External CI: Move llvm output folder to expected path (Part 1)"

### DIFF
--- a/.azuredevops/components/llvm-project.yml
+++ b/.azuredevops/components/llvm-project.yml
@@ -76,11 +76,11 @@ jobs:
         -DPACKAGE_VENDOR=AMD
         -DCLANG_LINK_FLANG_LEGACY=ON
         -DCMAKE_CXX_STANDARD=17
-        -DROCM_LLVM_BACKWARD_COMPAT_LINK=$(Build.BinariesDirectory)/lib/llvm
+        -DROCM_LLVM_BACKWARD_COMPAT_LINK=$(Build.BinariesDirectory)/llvm
         -DROCM_LLVM_BACKWARD_COMPAT_LINK_TARGET=./lib/llvm
         -GNinja
       cmakeBuildDir: 'llvm/build'
-      installDir: '$(Build.BinariesDirectory)/lib/llvm'
+      installDir: '$(Build.BinariesDirectory)/llvm'
 # use llvm-lit to run unit tests for llvm, clang, and lld
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
     parameters:

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -239,11 +239,6 @@ steps:
       script: ls -1R $(Agent.BuildDirectory)/rocm
 - ${{ if eq(parameters.skipLibraryLinking, false) }}:
   - task: Bash@3
-    displayName: temporary symlink
-    inputs:
-      targetType: inline
-      script: ln -s $(Agent.BuildDirectory)/rocm/lib/llvm $(Agent.BuildDirectory)/rocm/llvm
-  - task: Bash@3
     displayName: 'link ROCm shared libraries'
     inputs:
       targetType: inline
@@ -251,14 +246,14 @@ steps:
       ${{ if eq(parameters.extractToMnt, true) }}:
         script: |
           echo /mnt/rocm/lib | sudo tee -a /etc/ld.so.conf
-          echo /mnt/rocm/lib/llvm/lib | sudo tee -a /etc/ld.so.conf
+          echo /mnt/rocm/llvm/lib | sudo tee -a /etc/ld.so.conf
           sudo cat /etc/ld.so.conf
           sudo ldconfig -v
           ldconfig -p
       ${{ else }}:
         script: |
           echo $(Agent.BuildDirectory)/rocm/lib | sudo tee -a /etc/ld.so.conf
-          echo $(Agent.BuildDirectory)/rocm/lib/llvm/lib | sudo tee -a /etc/ld.so.conf
+          echo $(Agent.BuildDirectory)/rocm/llvm/lib | sudo tee -a /etc/ld.so.conf
           sudo cat /etc/ld.so.conf
           sudo ldconfig -v
           ldconfig -p


### PR DESCRIPTION
Reverts ROCm/ROCm#3588

Downstream dependencies failing to find device-libs. Will debug further.