### PR TITLE
Fix for hipother External CI pipeline

### DIFF
--- a/.azuredevops/components/HIP.yml
+++ b/.azuredevops/components/HIP.yml
@@ -58,6 +58,9 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
     parameters:
       checkoutRepo: matching_repo
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: hipother_repo
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
     parameters:
       dependencyList: ${{ parameters.rocmDependenciesAMD }}


### PR DESCRIPTION
Recompilation of hip for AMD backend uses Microsoft-hosted agent, so no need to worry about VM costs if we re-build for any hipother repo changes.