### PR TITLE
Add rocPyDecode with other changes

### DIFF
--- a/docs/reference/api-libraries.md
+++ b/docs/reference/api-libraries.md
@@ -25,6 +25,7 @@
 * {doc}`MIVisionX <mivisionx:index>`
 * {doc}`rocAL <rocal:index>`
 * {doc}`rocDecode <rocdecode:index>`
+* {doc}`rocPyDecode <rocpydecode:index>`
 * {doc}`ROCm Performance Primitives (RPP) <rpp:index>`
 :::
 
@@ -53,18 +54,6 @@
 * {doc}`RCCL <rccl:index>`
 :::
 
-(hip-runtime)=
-
-:::{grid-item-card}
-:class-card: sd-text-black
-:img-top: ../data/reference/banner-hip.jpg
-:img-alt: HIP APIs
-:padding: 2
-
-* {doc}`HIP runtime <hip:index>`
-* {doc}`HIPIFY <hipify:index>`
-:::
-
 (math-apis)=
 
 :::{grid-item-card}
@@ -78,24 +67,13 @@
 * {doc}`hipBLASLt <hipblaslt:index>`
 * {doc}`hipFFT <hipfft:index>` / {doc}`rocFFT <rocfft:index>`
 * {doc}`hipfort <hipfort:index>`
+* {doc}`hipRAND <hiprand:index>` / {doc}`rocRAND <rocrand:index>`
 * {doc}`hipSOLVER <hipsolver:index>` / {doc}`rocSOLVER <rocsolver:index>`
 * {doc}`hipSPARSE <hipsparse:index>` / {doc}`rocSPARSE <rocsparse:index>`
 * {doc}`hipSPARSELt <hipsparselt:index>`
 * {doc}`rocALUTION <rocalution:index>`
 * {doc}`rocWMMA <rocwmma:index>`
 * [Tensile](https://github.com/ROCm/Tensile)
-:::
-
-(random-number-apis)=
-
-:::{grid-item-card}
-:class-card: sd-text-black
-:img-top: ../data/reference/banner-random-number.jpg
-:img-alt: Random number APIs
-:padding: 2
-
-* {doc}`hipRAND <hiprand:index>`
-* {doc}`rocRAND <rocrand:index>`
 :::
 
 ::::


### PR DESCRIPTION
Add rocPyDecode to ROCm libraries page
Consolidate Random numbers under Math libraries
Remove HIP card from ROCm libraries page
To be cherry-picked into 6.2.0 docs