### PR TITLE
External CI: fix HIP pipeline ID for copyHIP

### DIFF
--- a/.azuredevops/components/copyHIP.yml
+++ b/.azuredevops/components/copyHIP.yml
@@ -26,6 +26,8 @@ jobs:
     parameters:
       componentName: HIP
       pipelineId: $(hip-pipeline-id)
+      useDefaultBranch: false
+      branchName: develop
   - template:  ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-prepare-package.yml
     parameters:
       sourceDir: $(Agent.BuildDirectory)/rocm

--- a/.azuredevops/components/copyHIP.yml
+++ b/.azuredevops/components/copyHIP.yml
@@ -26,8 +26,6 @@ jobs:
     parameters:
       componentName: HIP
       pipelineId: $(hip-pipeline-id)
-      useDefaultBranch: false
-      branchName: develop
   - template:  ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-prepare-package.yml
     parameters:
       sourceDir: $(Agent.BuildDirectory)/rocm

--- a/.azuredevops/components/copyHIP.yml
+++ b/.azuredevops/components/copyHIP.yml
@@ -24,9 +24,7 @@ jobs:
   - checkout: none
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
     parameters:
-      useDefaultBranch: false
       componentName: HIP
-      branchName: develop
   - template:  ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-prepare-package.yml
     parameters:
       sourceDir: $(Agent.BuildDirectory)/rocm

--- a/.azuredevops/components/copyHIP.yml
+++ b/.azuredevops/components/copyHIP.yml
@@ -25,6 +25,7 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
     parameters:
       componentName: HIP
+      piplineId: $(hip-pipeline-id)
   - template:  ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-prepare-package.yml
     parameters:
       sourceDir: $(Agent.BuildDirectory)/rocm

--- a/.azuredevops/components/copyHIP.yml
+++ b/.azuredevops/components/copyHIP.yml
@@ -25,7 +25,7 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
     parameters:
       componentName: HIP
-      piplineId: $(hip-pipeline-id)
+      pipelineId: $(hip-pipeline-id)
   - template:  ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-prepare-package.yml
     parameters:
       sourceDir: $(Agent.BuildDirectory)/rocm


### PR DESCRIPTION
Adds the HIP pipeline ID and removes the `develop` branch name from copyHIP.yml. Fixes clr errors for automatically triggered runs.

Successful run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=5813&view=results