### PR TITLE
External CI: add hipBLASLt to MIGraphX and ROCmValidationSuite

### DIFF
--- a/.azuredevops/components/AMDMIGraphX.yml
+++ b/.azuredevops/components/AMDMIGraphX.yml
@@ -11,6 +11,7 @@ parameters:
     - git
     - cmake
     - ninja-build
+    - libdrm-dev
     - libnuma-dev
     - python3-pip
     - python3-venv
@@ -34,17 +35,21 @@ parameters:
 - name: rocmDependencies
   type: object
   default:
-    - rocm-cmake
-    - llvm-project
-    - ROCR-Runtime
-    - clr
-    - rocminfo
-    - rocMLIR
-    - MIOpen
     - aomp
     - aomp-extras
-    - rocBLAS
+    - clr
     - composable_kernel
+    - hipBLAS
+    - hipBLAS-common
+    - hipBLASLt
+    - llvm-project
+    - MIOpen
+    - rocm-cmake
+    - ROCR-Runtime
+    - rocBLAS
+    - rocminfo
+    - rocMLIR
+    - rocprofiler-register
 
 jobs:
 - job: AMDMIGraphX
@@ -94,6 +99,7 @@ jobs:
         -DCMAKE_C_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/clang
         -DCMAKE_BUILD_TYPE=Release
         -DGPU_TARGETS=$(JOB_GPU_TARGET)
+        -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
         -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm/llvm;$(Agent.BuildDirectory)/rocm
         -DHALF_INCLUDE_DIR=$(Agent.BuildDirectory)/rocm/include
         -DMIGRAPHX_USE_COMPOSABLEKERNEL=OFF

--- a/.azuredevops/components/ROCmValidationSuite.yml
+++ b/.azuredevops/components/ROCmValidationSuite.yml
@@ -19,6 +19,8 @@ parameters:
   type: object
   default:
     - clr
+    - hipBLAS-common
+    - hipBLASLt
     - hipRAND
     - llvm-project
     - rocBLAS


### PR DESCRIPTION
Adds hipBLASLt and hipBLAS-common to MIGraphX and RVS to anticipate some PRs:
https://github.com/ROCm/AMDMIGraphX/pull/3371
https://github.com/ROCm/ROCmValidationSuite/pull/799

Also adds additional dependencies and an `AMDGPU_TARGETS` flag to resolve some MIGraphX cmake configuration warnings.