### PR TITLE
External CI: add hipBLASLt + roc/hipFFT to rocm-examples

### DIFF
--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -15,6 +15,8 @@ parameters:
     - AMDMIGraphX
     - clr
     - hipBLAS
+    - hipBLAS-common
+    - hipBLASLt
     - hipCUB
     - HIPIFY
     - hipRAND
@@ -58,10 +60,10 @@ jobs:
       dependencyList: ${{ parameters.rocmDependencies }}
       gpuTarget: $(JOB_GPU_TARGET)
       # CI case: download latest default branch build
-      ${{ if eq(parameters.checkoutRef, '') }}:
+      ${{ if eq(parameters.checkoutRef, '8038cfc3069d8333a8b0dfa4abe8b97c5ac3c5e7') }}:
         dependencySource: staging
       # manual build case: triggered by ROCm/ROCm repo
-      ${{ elseif ne(parameters.checkoutRef, '') }}:
+      ${{ elseif ne(parameters.checkoutRef, '8038cfc3069d8333a8b0dfa4abe8b97c5ac3c5e7') }}:
         dependencySource: tag-builds
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
     parameters:

--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -18,12 +18,14 @@ parameters:
     - hipBLAS-common
     - hipBLASLt
     - hipCUB
+    - hipFFT
     - HIPIFY
     - hipRAND
     - hipSOLVER
     - hipSPARSE
     - llvm-project
     - rocBLAS
+    - rocFFT
     - rocPRIM
     - rocprofiler-register
     - ROCR-Runtime
@@ -72,6 +74,7 @@ jobs:
         -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
         -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
         -DROCM_ROOT=$(Agent.BuildDirectory)/rocm
+        -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
         -DCMAKE_HIP_ARCHITECTURES=$(JOB_GPU_TARGET)
         -DCMAKE_EXE_LINKER_FLAGS=-fgpu-rdc
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml

--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -62,10 +62,10 @@ jobs:
       dependencyList: ${{ parameters.rocmDependencies }}
       gpuTarget: $(JOB_GPU_TARGET)
       # CI case: download latest default branch build
-      ${{ if eq(parameters.checkoutRef, '') }}:
+      ${{ if eq(parameters.checkoutRef, '8038cfc3069d8333a8b0dfa4abe8b97c5ac3c5e7') }}:
         dependencySource: staging
       # manual build case: triggered by ROCm/ROCm repo
-      ${{ elseif ne(parameters.checkoutRef, '') }}:
+      ${{ elseif ne(parameters.checkoutRef, '8038cfc3069d8333a8b0dfa4abe8b97c5ac3c5e7') }}:
         dependencySource: tag-builds
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
     parameters:

--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -62,10 +62,10 @@ jobs:
       dependencyList: ${{ parameters.rocmDependencies }}
       gpuTarget: $(JOB_GPU_TARGET)
       # CI case: download latest default branch build
-      ${{ if eq(parameters.checkoutRef, '8038cfc3069d8333a8b0dfa4abe8b97c5ac3c5e7') }}:
+      ${{ if eq(parameters.checkoutRef, '') }}:
         dependencySource: staging
       # manual build case: triggered by ROCm/ROCm repo
-      ${{ elseif ne(parameters.checkoutRef, '8038cfc3069d8333a8b0dfa4abe8b97c5ac3c5e7') }}:
+      ${{ elseif ne(parameters.checkoutRef, '') }}:
         dependencySource: tag-builds
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
     parameters:

--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -60,10 +60,10 @@ jobs:
       dependencyList: ${{ parameters.rocmDependencies }}
       gpuTarget: $(JOB_GPU_TARGET)
       # CI case: download latest default branch build
-      ${{ if eq(parameters.checkoutRef, '8038cfc3069d8333a8b0dfa4abe8b97c5ac3c5e7') }}:
+      ${{ if eq(parameters.checkoutRef, '') }}:
         dependencySource: staging
       # manual build case: triggered by ROCm/ROCm repo
-      ${{ elseif ne(parameters.checkoutRef, '8038cfc3069d8333a8b0dfa4abe8b97c5ac3c5e7') }}:
+      ${{ elseif ne(parameters.checkoutRef, '') }}:
         dependencySource: tag-builds
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
     parameters:


### PR DESCRIPTION
Resolves build failure for: https://github.com/ROCm/rocm-examples/pull/141
Also adds the AMDGPU_TARGETS flag to quiet a cmake warning.

Successful build:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=6032&view=results