### PR TITLE
External CI: Build Fixes for llvm-project and rocBLAS

### DIFF
--- a/.azuredevops/components/llvm-project.yml
+++ b/.azuredevops/components/llvm-project.yml
@@ -41,6 +41,7 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
     parameters:
       dependencyList: ${{ parameters.rocmDependencies }}
+      skipLlvmSymlink: true
       # CI case: download latest default branch build
       ${{ if eq(parameters.checkoutRef, '') }}:
         dependencySource: staging

--- a/.azuredevops/components/rocBLAS.yml
+++ b/.azuredevops/components/rocBLAS.yml
@@ -37,6 +37,8 @@ parameters:
     - rocm-core
     - aomp
     - aomp-extras
+    - hipBLAS-common
+    - hipBLASLt
 
 jobs:
 - job: rocBLAS


### PR DESCRIPTION
- llvm-project should not use default symbolic link to llvm-project.
- rocBLAS now depends on hipBLASLt.

Passing build logs:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=6104&view=results
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=6111&view=results