### PR TITLE
External CI: Add cmake prefix path to nightly pytorch

### DIFF
--- a/.azuredevops/nightly/pytorch.yml
+++ b/.azuredevops/nightly/pytorch.yml
@@ -146,8 +146,6 @@ jobs:
     value: 3.10
   - name: PYTORCH_ROOT
     value: $(Build.SourcesDirectory)/pytorch
-  - name: CMAKE_ARGS
-    value: -GNinja
   - name: DESIRED_DEVTOOLSET
     value: cxx11-abi
   pool: ${{ variables.ULTRA_BUILD_POOL }}
@@ -245,7 +243,7 @@ jobs:
         GPU_TARGET=$(JOB_GPU_TARGET)
         DESIRED_PYTHON=$(DESIRED_PYTHON)
         PYTORCH_ROOT=$(PYTORCH_ROOT)
-        CMAKE_ARGS=$(CMAKE_ARGS)
+        CMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
         AOTRITON_INSTALLED_PREFIX=$(AOTRITON_INSTALLED_PREFIX)
         DESIRED_DEVTOOLSET=$(DESIRED_DEVTOOLSET)
         TORCH_PACKAGE_NAME=torch.$(ROCM_BRANCH).$(JOB_GPU_TARGET)


### PR DESCRIPTION
This change is for the build to find new hipBLAS-common dependency. This commit is being pushed in a parallel with llvm-project pipeline fixes that should hopefully resolve the nightly build failures for this pytorch pipeline.