### PR TITLE
Correct ttm to amdttm

### DIFF
--- a/docs/how-to/system-optimization/mi300a.rst
+++ b/docs/how-to/system-optimization/mi300a.rst
@@ -136,7 +136,7 @@ This section describes performance-based settings.
 
   .. code-block:: shell
 
-     cat /sys/module/ttm/parameters/pages_limit 
+     cat /sys/module/amdttm/parameters/pages_limit 
   
   To set the amount of allocatable memory to all available memory on all four APU devices, run these commands:
 
@@ -158,7 +158,7 @@ This section describes performance-based settings.
 
   .. code-block:: shell
 
-     cat /sys/module/ttm/parameters/pages_limit 
+     cat /sys/module/amdttm/parameters/pages_limit 
 
   .. note::
 


### PR DESCRIPTION
The original content incorrectly had `ttm` in path rather than `amdttm`.