### PR TITLE
Fix intersphinx links

### DIFF
--- a/docs/how-to/rocm-for-ai/install.rst
+++ b/docs/how-to/rocm-for-ai/install.rst
@@ -24,23 +24,23 @@ If you’re new to ROCm, refer to the :doc:`ROCm quick start install guide for L
 If you’re using a Radeon GPU for graphics-accelerated applications, refer to the
 :doc:`Radeon installation instructions <radeon:docs/install/install-radeon>`.
 
-ROCm supports two methods for installation. There is no difference in the final ROCm installation between these two
-methods. You can also opt for :ref:`single-version or multi-version installation
-<rocm-install-on-linux:installation-types>`.
+ROCm supports multiple :doc:`installation methods <rocm-install-on-linux:install/install-overview>`:
 
-*  :doc:`Using your Linux distribution's package manager <rocm-install-on-linux:how-to/native-install/index>`
+* :doc:`Using your Linux distribution's package manager <rocm-install-on-linux:install/native-install/index>`
 
-*  :doc:`Using the AMDGPU installer <rocm-install-on-linux:how-to/amdgpu-install>`
+* :doc:`Using the AMDGPU installer <rocm-install-on-linux:install/amdgpu-install>`
+
+* :ref:`Multi-version installation <rocm-install-on-linux:installation-types>`.
 
 .. grid:: 1
 
    .. grid-item-card:: Post-install
 
-      Follow the :doc:`post-installation instructions <rocm-install-on-linux:how-to/native-install/post-install>` to
+      Follow the :doc:`post-installation instructions <rocm-install-on-linux:install/post-install>` to
       configure your system linker, PATH, and verify the installation.
 
       If you encounter any issues during installation, refer to the
-      :doc:`Installation troubleshooting <rocm-install-on-linux:how-to/native-install/install-faq>` guide.
+      :doc:`Installation troubleshooting <rocm-install-on-linux:reference/install-faq>` guide.
 
 Machine learning frameworks
 ===========================

--- a/docs/how-to/system-optimization/mi100.md
+++ b/docs/how-to/system-optimization/mi100.md
@@ -365,9 +365,9 @@ installed.
 ## System management
 
 For a complete guide on how to install/manage/uninstall ROCm on Linux, refer to
-{doc}`Quick-start (Linux)<rocm-install-on-linux:tutorial/quick-start>`. To verify that the installation was
+{doc}`Quick-start (Linux)<rocm-install-on-linux:install/quick-start>`. To verify that the installation was
 successful, refer to the
-{doc}`post-install instructions<rocm-install-on-linux:how-to/native-install/post-install>` and
+{doc}`post-install instructions<rocm-install-on-linux:install/post-install>` and
 [system tools](../../reference/rocm-tools.md). Should verification
 fail, consult the [System Debugging Guide](../system-debugging.md).
 

--- a/docs/how-to/system-optimization/mi200.md
+++ b/docs/how-to/system-optimization/mi200.md
@@ -350,9 +350,9 @@ installed.
 ## System management
 
 For a complete guide on how to install/manage/uninstall ROCm on Linux, refer to
-{doc}`Quick-start (Linux)<rocm-install-on-linux:tutorial/quick-start>`. For verifying that the
+{doc}`Quick-start (Linux)<rocm-install-on-linux:install/quick-start>`. For verifying that the
 installation was successful, refer to the
-{doc}`post-install instructions<rocm-install-on-linux:how-to/native-install/post-install>` and
+{doc}`post-install instructions<rocm-install-on-linux:install/post-install>` and
 [system tools](../../reference/rocm-tools.md). Should verification
 fail, consult the [System Debugging Guide](../system-debugging.md).
 

--- a/docs/how-to/system-optimization/mi300a.rst
+++ b/docs/how-to/system-optimization/mi300a.rst
@@ -272,9 +272,9 @@ System management
 ========================================
 
 For a complete guide on installing, managing, and uninstalling ROCm on Linux, see
-:doc:`Quick-start (Linux)<rocm-install-on-linux:tutorial/quick-start>`. To verify that the
+:doc:`Quick-start (Linux)<rocm-install-on-linux:install/quick-start>`. To verify that the
 installation was successful, see the
-:doc:`Post-installation instructions<rocm-install-on-linux:install/native-install/post-install>` and 
+:doc:`Post-installation instructions<rocm-install-on-linux:install/post-install>` and 
 :doc:`ROCm tools <../../reference/rocm-tools>` guides. If verification
 fails, consult the :doc:`System debugging guide <../system-debugging>`.
 

--- a/docs/how-to/system-optimization/mi300x.rst
+++ b/docs/how-to/system-optimization/mi300x.rst
@@ -534,7 +534,7 @@ optimizing user applications.
 For a complete guide on how to install, manage, or uninstall ROCm on Linux, refer to
 :doc:`rocm-install-on-linux:install/quick-start`. For verifying that the
 installation was successful, refer to the
-:doc:`rocm-install-on-linux:install/native-install/post-install`.
+:doc:`rocm-install-on-linux:install/post-install`.
 Should verification fail, consult :doc:`/how-to/system-debugging`.
 
 Hardware verification with ROCm


### PR DESCRIPTION
This PR fixes intersphinx links in ROCm/ROCm based on Sphinx warnings/errors.

The dead link checker cannot find broken intersphinx links. Broken intersphinx links must be found as part of the review process by checking the Read the Docs build trace or by using `linkcheck` (https://docs.readthedocs.io/en/stable/guides/intersphinx.html).