### PR TITLE
External CI: create symlinks for llvm binaries

### DIFF
--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -71,10 +71,10 @@ jobs:
       dependencyList: ${{ parameters.rocmDependencies }}
       gpuTarget: $(JOB_GPU_TARGET)
       # CI case: download latest default branch build
-      ${{ if eq(parameters.checkoutRef, '') }}:
+      ${{ if eq(parameters.checkoutRef, 'develop') }}:
         dependencySource: staging
       # manual build case: triggered by ROCm/ROCm repo
-      ${{ elseif ne(parameters.checkoutRef, '') }}:
+      ${{ elseif ne(parameters.checkoutRef, 'develop') }}:
         dependencySource: tag-builds
   - script: sudo ln -s $(Agent.BuildDirectory)/rocm /opt/rocm
     displayName: ROCm symbolic link

--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -71,10 +71,10 @@ jobs:
       dependencyList: ${{ parameters.rocmDependencies }}
       gpuTarget: $(JOB_GPU_TARGET)
       # CI case: download latest default branch build
-      ${{ if eq(parameters.checkoutRef, 'develop') }}:
+      ${{ if eq(parameters.checkoutRef, '') }}:
         dependencySource: staging
       # manual build case: triggered by ROCm/ROCm repo
-      ${{ elseif ne(parameters.checkoutRef, 'develop') }}:
+      ${{ elseif ne(parameters.checkoutRef, '') }}:
         dependencySource: tag-builds
   - script: sudo ln -s $(Agent.BuildDirectory)/rocm /opt/rocm
     displayName: ROCm symbolic link

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -241,6 +241,14 @@ steps:
     inputs:
       targetType: inline
       script: sudo ln -s $(Agent.BuildDirectory)/rocm/llvm $(Agent.BuildDirectory)/rocm/lib/llvm
+  - task: Bash@3
+    displayName: Symlink executables from rocm/llvm/bin to rocm/bin
+    inputs:
+      targetType: inline
+      script: |
+        for file in amdclang amdclang++ amdclang-cl amdclang-cpp amdflang amdlld aompcc mygpu mycpu offload-arch; do
+          sudo ln -s $(Agent.BuildDirectory)/rocm/llvm/bin/$file $(Agent.BuildDirectory)/rocm/bin/$file
+        done
 - task: Bash@3
   displayName: 'List downloaded ROCm files'
   inputs:


### PR DESCRIPTION
Fixes a hipBLASLt failure introduced by https://github.com/ROCm/hipBLASLt/pull/893
https://github.com/ROCm/hipBLASLt/pull/893/files#diff-cb27de26e92cd3dc56a24df9a28cad5693ef9123a74f2e20d1fde1d8aafe9c6eR37

Build log: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=7007&view=results

A normal ROCm installation does have these symlinks:

```
/opt/rocm-6.2.0/bin$ ls -la | grep llvm/bin
lrwxrwxrwx 1 root root        24 Aug 15 13:59 amdclang -> ../lib/llvm/bin/amdclang
lrwxrwxrwx 1 root root        26 Aug 15 13:59 amdclang++ -> ../lib/llvm/bin/amdclang++
lrwxrwxrwx 1 root root        27 Aug 15 13:59 amdclang-cl -> ../lib/llvm/bin/amdclang-cl
lrwxrwxrwx 1 root root        28 Aug 15 13:59 amdclang-cpp -> ../lib/llvm/bin/amdclang-cpp
lrwxrwxrwx 1 root root        24 Aug 15 13:59 amdflang -> ../lib/llvm/bin/amdflang
lrwxrwxrwx 1 root root        22 Aug 15 13:59 amdlld -> ../lib/llvm/bin/amdlld
lrwxrwxrwx 1 root root        22 Jul 31 14:43 aompcc -> ../lib/llvm/bin/aompcc
lrwxrwxrwx 1 root root        21 Jul 31 14:43 mygpu -> ../lib/llvm/bin/mygpu
lrwxrwxrwx 1 root root        22 Jul 31 14:43 mymcpu -> ../lib/llvm/bin/mymcpu
lrwxrwxrwx 1 root root        28 Aug 15 13:59 offload-arch -> ../lib/llvm/bin/offload-arch
```