### PR TITLE
External CI: fix rocm-examples dependencies-other

### DIFF
--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -9,6 +9,7 @@ parameters:
   type: object
   default:
     - libglfw3-dev
+    - python3-pip
 - name: rocmDependencies
   type: object
   default:

--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -49,13 +49,13 @@ jobs:
       gfx90a:
         JOB_GPU_TARGET: gfx90a
   steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
     parameters:
       checkoutRepo: ${{ parameters.checkoutRepo }}
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
-    parameters:
-      aptPackages: ${{ parameters.aptPackages }}
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
     parameters:
       dependencyList: ${{ parameters.rocmDependencies }}


### PR DESCRIPTION
Fixes error for: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=7398&view=results