### PR TITLE
Add missing make command to bitsandbytes install commands

### DIFF
--- a/docs/how-to/llm-fine-tuning-optimization/model-quantization.rst
+++ b/docs/how-to/llm-fine-tuning-optimization/model-quantization.rst
@@ -189,6 +189,9 @@ Installing bitsandbytes
       # Use -DBNB_ROCM_ARCH to specify target GPU arch
       cmake -DBNB_ROCM_ARCH="gfx942" -DCOMPUTE_BACKEND=hip -S .
 
+      # Compile the project
+      make
+
       # Install 
       python setup.py install
 


### PR DESCRIPTION
Users have been facing issues due to incomplete installation documentation.

See https://github.com/ROCm/bitsandbytes README