### PR TITLE
External CI: half component smoke test

### DIFF
--- a/.azuredevops/components/half.yml
+++ b/.azuredevops/components/half.yml
@@ -53,3 +53,13 @@ jobs:
         -DBUILD_FILE_REORG_BACKWARD_COMPATIBILITY=OFF
         -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
+  # only run test03 because test11 has too many test cases, taking way too long
+  - task: Bash@3
+    displayName: test03
+    inputs:
+      targetType: inline
+      script: |
+        make clean
+        make test03
+        ./bin/test
+      workingDirectory: $(Build.SourcesDirectory)/test


### PR DESCRIPTION
Tried out test11, even on a more powerful VM. Test was tracking to take more than an hour. Settled for test03 for smoke tests.

https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=7900&view=results