### PR TITLE
Update link to rocRAND data type support

### DIFF
--- a/docs/compatibility/precision-support.rst
+++ b/docs/compatibility/precision-support.rst
@@ -410,7 +410,7 @@ description, refer to the corresponding library data type support page.
         - ❌/❌
         - ❌/❌
       *
-        - rocRAND (:doc:`details <rocrand:data-type-support>`)
+        - rocRAND (:doc:`details <rocrand:api-reference/data-type-support>`)
         - -/✅
         - -/✅
         - -/✅


### PR DESCRIPTION
The change in the link target is required due to changes in https://github.com/ROCm/rocRAND/pull/548.