### PR TITLE
Add starting-versions flag to autotag script

### DIFF
--- a/tools/autotag/README.md
+++ b/tools/autotag/README.md
@@ -23,7 +23,7 @@
 To generate the changelog from 5.0.0 up to and including 6.1.2:
 
 ```sh
-python3 tag_script.py -t $GITHUB_ACCESS_TOKEN --no-release --no-pulls --do-previous --compile_file ../../CHANGELOG.md --branch release/rocm-rel-6.1 6.1.2
+python3 tag_script.py -t $GITHUB_ACCESS_TOKEN --no-release --no-pulls --starting-version=5.0.0 --compile_file ../../CHANGELOG.md --branch release/rocm-rel-6.1 6.1.2
 ```
 
 To generate the release notes only for 6.1.2:
@@ -37,7 +37,7 @@ python3 tag_script.py -t $GITHUB_ACCESS_TOKEN --no-release --no-pulls --compile_
 > If branch cannot be found, edit default.xml at root.
 > Sometimes the script doesn't know whether to include or exclude an entry for a specific release. Continue this part by accepting (Y) or rejecting (N) entries.
 > The end result should be a newly generated changelog in the project root.
-> Compiling the changelog without the `--do-previous`-flag will always think that all libraries are new since no previous version of said library has been parsed.
+> If the `--starting-version` flag is not set, the script will not get changelogs from previous versions.
 > Trying to run without a token is possible but GitHub enforces stricter rate limits and is therefore not advised.
 
 * Copy over the first part of the changelog and replace the old release notes in RELEASE.md.


### PR DESCRIPTION
Closes https://github.com/ROCm/ROCm/issues/3585

ie: add a prev release option to autotag script so that it does not have to start at 5.0.0

# Before

passing in the `--do-previous` flag would start from 5.0.0

# After

pass in the `starting-versions=<a.b.c>` flag where a.b.c is the version to start from