### PR TITLE
External CI: rdc smoke tests

### DIFF
--- a/.azuredevops/components/rdc.yml
+++ b/.azuredevops/components/rdc.yml
@@ -18,16 +18,35 @@ parameters:
     - autoconf
     - libtool
     - pkg-config
+    - libdrm-dev
+    - libyaml-cpp-dev
 - name: rocmDependencies
   type: object
   default:
-    - rocm-cmake
-    - llvm-project
-    - ROCR-Runtime
+    - amdsmi
     - clr
+    - llvm-project
+    - rocBLAS
+    - rocm-cmake
     - rocminfo
     - rocm_smi_lib
+    - ROCmValidationSuite
+    - rocprofiler
+    - rocprofiler-register
+    - ROCR-Runtime
+- name: rocmTestDependencies
+  type: object
+  default:
     - amdsmi
+    - clr
+    - llvm-project
+    - rocm-cmake
+    - rocminfo
+    - rocm_smi_lib
+    - ROCmValidationSuite
+    - rocprofiler
+    - rocprofiler-register
+    - ROCR-Runtime
 
 jobs:
 - job: rdc
@@ -37,6 +56,12 @@ jobs:
   pool: ${{ variables.MEDIUM_BUILD_POOL }}
   workspace:
     clean: all
+  strategy:
+    matrix:
+      gfx942:
+        JOB_GPU_TARGET: gfx942
+      gfx90a:
+        JOB_GPU_TARGET: gfx90a
   steps:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
     parameters:
@@ -48,6 +73,7 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
     parameters:
       dependencyList: ${{ parameters.rocmDependencies }}
+      gpuTarget: $(JOB_GPU_TARGET)
       # CI case: download latest default branch build
       ${{ if eq(parameters.checkoutRef, '') }}:
         dependencySource: staging
@@ -71,11 +97,71 @@ jobs:
         -DBUILD_SHARED_LIBS=ON
         -DCMAKE_INSTALL_LIBDIR=lib
         -DCMAKE_BUILD_TYPE=Release
+        -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
         -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
     parameters:
       extraBuildFlags: >-
         -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
         -DGRPC_ROOT="$(Build.SourcesDirectory)/bin"
+        -DBUILD_RVS=ON
+        -DBUILD_PROFILER=ON
         -DBUILD_TESTS=ON
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
+    parameters:
+      gpuTarget: $(JOB_GPU_TARGET)
+
+- job: rdc_testing
+  dependsOn: rdc
+  condition: succeeded()
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool: $(JOB_TEST_POOL)
+  workspace:
+    clean: all
+  strategy:
+    matrix:
+      gfx942:
+        JOB_GPU_TARGET: gfx942
+        JOB_TEST_POOL: ${{ variables.GFX942_TEST_POOL }}
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-aqlprofile.yml
+    parameters:
+      ${{ if eq(parameters.checkoutRef, '') }}:
+        dependencySource: staging
+      ${{ elseif ne(parameters.checkoutRef, '') }}:
+        dependencySource: tag-builds
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
+    parameters:
+      dependencyList: ${{ parameters.rocmTestDependencies }}
+      gpuTarget: $(JOB_GPU_TARGET)
+      ${{ if eq(parameters.checkoutRef, '') }}:
+        dependencySource: staging
+      ${{ elseif ne(parameters.checkoutRef, '') }}:
+        dependencySource: tag-builds
+  - task: Bash@3
+    displayName: Setup test environment
+    inputs:
+      targetType: inline
+      script: |
+        sudo rm -rf /opt/rocm
+        sudo rm -rf /usr/sbin/rdcd
+        sudo ln -s $(Agent.BuildDirectory)/rocm /opt/rocm
+        sudo ln -s $(Agent.BuildDirectory)/rocm/bin/rdcd /usr/sbin/rdcd
+        echo $(Agent.BuildDirectory)/rocm/lib/rdc/grpc/lib | sudo tee /etc/ld.so.conf.d/grpc.conf
+        sudo ldconfig -v
+  - task: Bash@3
+    displayName: Test rdc
+    inputs:
+      targetType: inline
+      script: >-
+        $(Agent.BuildDirectory)/rocm/share/rdc/rdctst_tests/rdctst
+        --batch_mode
+        --start_rdcd
+        --unauth_comm

--- a/.azuredevops/templates/steps/artifact-download.yml
+++ b/.azuredevops/templates/steps/artifact-download.yml
@@ -76,9 +76,10 @@ parameters:
 - name: allowPartiallySucceededBuilds
   type: object
   default:
-    - rocm-cmake
     - amdsmi
     - HIPIFY
+    - rdc
+    - rocm-cmake
     - rocm_smi_lib
     - rocFFT
     - MIVisionX


### PR DESCRIPTION
- Referred to public documentation, build instructions, source code in tests directory, and iterative runs to modify build flags.
- rdci test failures are known due to singleton nature of rocprofiler, but gtest attempting to spawn multiple instances. There is an internal ticket to track the issue.

[Build Log with the passing rdcd and known failing rdci tests](https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=8065&view=results)