### PR TITLE
External CI: Replace libomp-dev dependencies with aomp

### DIFF
--- a/.azuredevops/components/hipBLAS.yml
+++ b/.azuredevops/components/hipBLAS.yml
@@ -16,7 +16,6 @@ parameters:
     - libgtest-dev
     - wget
     - python3-pip
-    - libomp-dev
 - name: rocmDependencies
   type: object
   default:
@@ -46,6 +45,7 @@ parameters:
     - rocBLAS
     - rocSPARSE
     - rocSOLVER
+    - roctracer
 
 jobs:
 - job: hipBLAS

--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -16,7 +16,6 @@ parameters:
     - python3-pip
     - python3-venv
     - gfortran
-    - libomp-dev
     - libblas-dev
     - ccache
 - name: pipModules
@@ -66,6 +65,8 @@ jobs:
     value: $(Agent.BuildDirectory)/rocm/bin/hipcc
   - name: PATH
     value: $(Agent.BuildDirectory)/rocm/llvm/bin:$(Agent.BuildDirectory)/rocm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
+  - name: DAY_STRING
+    value: $[format('{0:ddMMyyyy}', pipeline.startTime)]
   pool: ${{ variables.ULTRA_BUILD_POOL }}
   workspace:
     clean: all

--- a/.azuredevops/components/hipFFT.yml
+++ b/.azuredevops/components/hipFFT.yml
@@ -14,11 +14,11 @@ parameters:
     - libgtest-dev
     - libfftw3-dev
     - python3-pip
-    - libomp-14-dev
 # rocm dependencies should match dependencies-rocm.yml
 - name: rocmDependencies
   type: object
   default:
+    - aomp
     - rocRAND
     - hipRAND
     - llvm-project

--- a/.azuredevops/components/hipSPARSELt.yml
+++ b/.azuredevops/components/hipSPARSELt.yml
@@ -15,7 +15,6 @@ parameters:
     - python3-pip
     - gfortran
     - libgfortran5
-    - libomp-dev
     - libopenblas-dev
 - name: pipModules
   type: object

--- a/.azuredevops/components/rocWMMA.yml
+++ b/.azuredevops/components/rocWMMA.yml
@@ -16,10 +16,10 @@ parameters:
     - googletest
     - libfftw3-dev
     - git
-    - libomp-dev
 - name: rocmDependencies
   type: object
   default:
+    - aomp
     - rocm-cmake
     - llvm-project
     - ROCR-Runtime
@@ -42,6 +42,7 @@ parameters:
     - rocminfo
     - rocprofiler-register
     - ROCR-Runtime
+    - roctracer
 
 jobs:
 - job: rocWMMA

--- a/.azuredevops/components/rpp.yml
+++ b/.azuredevops/components/rpp.yml
@@ -9,13 +9,12 @@ parameters:
   type: object
   default:
     - cmake
-    - libomp-dev # needed to pass flag step
     - ninja-build
     - clang
 - name: rocmDependencies
   type: object
   default:
-    - aomp # needed to pass build step
+    - aomp
     - clr
     - half
     - llvm-project


### PR DESCRIPTION
Add roctracer dependency for hipBLAS and rocWMMA testing.

**_Build Logs_**
[hipBLAS](https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=8443&view=results)
[hipBLASLt](https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=8435&view=results)
[hipFFT](https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=8436&view=results)
[hipSPARSELt](https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=8437&view=results)
[rocWMMA](https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=8444&view=results)
[rpp](https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=8439&view=results)