### PR TITLE
External CI: fix hip-tests symlink creation

### DIFF
--- a/.azuredevops/components/hip-tests.yml
+++ b/.azuredevops/components/hip-tests.yml
@@ -89,7 +89,7 @@ jobs:
       gpuTarget: $(JOB_GPU_TARGET)
 
 - job: hip_tests_testing
-  timeoutInMinutes: 180
+  timeoutInMinutes: 240
   dependsOn: hip_tests
   condition: succeeded()
   variables:
@@ -130,6 +130,7 @@ jobs:
     inputs:
       targetType: inline
       script: |
+        sudo rm -rf /opt/rocm
         sudo mkdir -p /opt/rocm/bin
         sudo ln -s $(Agent.BuildDirectory)/rocm/bin/rocm_agent_enumerator /opt/rocm/bin/rocm_agent_enumerator
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml


### PR DESCRIPTION
Increases time to 4 hours since a previous run exceeded the limit