### PR TITLE
External CI: rpp tests

### DIFF
--- a/.azuredevops/components/rpp.yml
+++ b/.azuredevops/components/rpp.yml
@@ -9,8 +9,18 @@ parameters:
   type: object
   default:
     - cmake
+    - libopencv-dev
+    - libsndfile1-dev
+    - libstdc++-12-dev
+    - imagemagick
     - ninja-build
     - clang
+- name: pipModules
+  type: object
+  default:
+    - openpyxl
+    - pandas
+    - sphinx
 - name: rocmDependencies
   type: object
   default:
@@ -19,6 +29,18 @@ parameters:
     - half
     - llvm-project
     - rocminfo
+    - ROCR-Runtime
+- name: rocmTestDependencies
+  type: object
+  default:
+    - aomp
+    - clr
+    - half
+    - hipTensor
+    - llvm-project
+    - rocm-cmake
+    - rocminfo
+    - rocprofiler-register
     - ROCR-Runtime
 
 jobs:
@@ -68,3 +90,92 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
     parameters:
       gpuTarget: $(JOB_GPU_TARGET)
+
+- job: rpp_testing
+  dependsOn: rpp
+  condition: succeeded()
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  - name: LD_LIBRARY_PATH
+    value: $(Agent.BuildDirectory)/rocm/lib;$(Agent.BuildDirectory)/rocm/llvm/lib
+  pool: $(JOB_TEST_POOL)
+  workspace:
+    clean: all
+  strategy:
+    matrix:
+      gfx942:
+        JOB_GPU_TARGET: gfx942
+        JOB_TEST_POOL: ${{ variables.GFX942_TEST_POOL }}
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+      pipModules: ${{ parameters.pipModules }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
+    parameters:
+      gpuTarget: $(JOB_GPU_TARGET)
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-aqlprofile.yml
+    parameters:
+      ${{ if eq(parameters.checkoutRef, '') }}:
+        dependencySource: staging
+      ${{ elseif ne(parameters.checkoutRef, '') }}:
+        dependencySource: tag-builds
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
+    parameters:
+      dependencyList: ${{ parameters.rocmTestDependencies }}
+      gpuTarget: $(JOB_GPU_TARGET)
+      ${{ if eq(parameters.checkoutRef, '') }}:
+        dependencySource: staging
+      ${{ elseif ne(parameters.checkoutRef, '') }}:
+        dependencySource: tag-builds
+  # Dependencies from: https://github.com/ROCm/rpp/blob/develop/utilities/test_suite/README.md
+  - task: Bash@3
+    displayName: Build and install Turbo JPEG
+    inputs:
+      targetType: 'inline'
+      script: |
+        sudo apt-get install nasm
+        sudo apt-get install wget
+        git clone -b 3.0.2 https://github.com/libjpeg-turbo/libjpeg-turbo.git 
+        cd libjpeg-turbo
+        mkdir build
+        cd build
+        cmake -DCMAKE_INSTALL_PREFIX=/usr \
+              -DCMAKE_BUILD_TYPE=RELEASE  \
+              -DENABLE_STATIC=FALSE       \
+              -DCMAKE_INSTALL_DEFAULT_LIBDIR=lib  \
+              -DWITH_JPEG8=TRUE           \
+              ..
+        make -j$nproc
+        sudo make install
+  - task: Bash@3
+    displayName: Build and install Nifti
+    inputs:
+      targetType: 'inline'
+      script: |
+        git clone https://github.com/NIFTI-Imaging/nifti_clib.git
+        cd nifti_clib
+        mkdir build
+        cd build
+        cmake ..
+        sudo make -j$nproc install
+  - task: Bash@3
+    displayName: Build rpp tests
+    inputs:
+      targetType: 'inline'
+      script: |
+        sudo rm -rf /opt/rocm
+        sudo ln -s $(Agent.BuildDirectory)/rocm /opt/rocm
+        mkdir rpp-tests
+        cd rpp-tests
+        cmake /opt/rocm/share/rpp/test \
+          -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++ \
+          -DCMAKE_C_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
+    parameters:
+      componentName: rpp
+      testExecutable: 'export PATH=$(Agent.BuildDirectory)/rocm/llvm/bin:$PATH; CC=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang CMAKE_VERBOSE_MAKEFILE=ON VERBOSE=1 ctest'
+      testDir: 'rpp-tests'
+  - script: sudo rm /opt/rocm

--- a/.azuredevops/templates/steps/artifact-download.yml
+++ b/.azuredevops/templates/steps/artifact-download.yml
@@ -86,6 +86,7 @@ parameters:
     - rocm-cmake
     - rocm_smi_lib
     - rocFFT
+    - rpp
     - MIVisionX
 # BELOW REQUIRED IF useDefaultBranch false
 - name: branchName


### PR DESCRIPTION
Adds default, voxel, and audio tests for RPP. `Tensor_hip` tests are currently failing due to a linker error with OpenMP, compiler team is investigating.

Build log, default tests only (7 min):
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=8881&view=results