### PR TITLE
External CI: omnitrace tests

### DIFF
--- a/.azuredevops/components/omnitrace.yml
+++ b/.azuredevops/components/omnitrace.yml
@@ -121,7 +121,7 @@ jobs:
     displayName: Set up omnitrace env
     inputs:
       targetType: inline
-      script : source share/omnitrace/setup-env.sh
+      script: source share/omnitrace/setup-env.sh
       workingDirectory: build
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
     parameters:

--- a/.azuredevops/components/omnitrace.yml
+++ b/.azuredevops/components/omnitrace.yml
@@ -74,10 +74,10 @@ jobs:
       dependencyList: ${{ parameters.rocmDependencies }}
       gpuTarget: $(JOB_GPU_TARGET)
       # CI case: download latest default branch build
-      ${{ if eq(parameters.checkoutRef, '') }}:
+      ${{ if eq(parameters.checkoutRef, 'main') }}:
         dependencySource: staging
       # manual build case: triggered by ROCm/ROCm repo
-      ${{ elseif ne(parameters.checkoutRef, '') }}:
+      ${{ elseif ne(parameters.checkoutRef, 'main') }}:
         dependencySource: tag-builds
   - task: Bash@3
     displayName: ROCm symbolic link

--- a/.azuredevops/components/omnitrace.yml
+++ b/.azuredevops/components/omnitrace.yml
@@ -10,8 +10,10 @@ parameters:
   type: object
   default:
     - autoconf
+    - autotools-dev
     - bison
     - build-essential
+    - bzip2
     - clang
     - cmake
     - environment-modules
@@ -19,6 +21,8 @@ parameters:
     - libdrm-dev
     - libfabric-dev
     - libiberty-dev
+    - libpapi-dev
+    - libpfm4-dev
     - libtool
     - libopenmpi-dev
     - m4
@@ -26,6 +30,7 @@ parameters:
     - software-properties-common
     - python3-pip
     - texinfo
+    - zlib1g-dev
 - name: pipModules
   type: object
   default:
@@ -112,6 +117,12 @@ jobs:
         -DOMNITRACE_USE_MPI=ON
         -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
       multithreadFlag: -- -j32
+  - task: Bash@3
+    displayName: Set up omnitrace env
+    inputs:
+      targetType: inline
+      script : source share/omnitrace/setup-env.sh
+      workingDirectory: build
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
     parameters:
       componentName: omnitrace

--- a/.azuredevops/components/omnitrace.yml
+++ b/.azuredevops/components/omnitrace.yml
@@ -79,10 +79,10 @@ jobs:
       dependencyList: ${{ parameters.rocmDependencies }}
       gpuTarget: $(JOB_GPU_TARGET)
       # CI case: download latest default branch build
-      ${{ if eq(parameters.checkoutRef, 'main') }}:
+      ${{ if eq(parameters.checkoutRef, '') }}:
         dependencySource: staging
       # manual build case: triggered by ROCm/ROCm repo
-      ${{ elseif ne(parameters.checkoutRef, 'main') }}:
+      ${{ elseif ne(parameters.checkoutRef, '') }}:
         dependencySource: tag-builds
   - task: Bash@3
     displayName: ROCm symbolic link

--- a/.azuredevops/components/omnitrace.yml
+++ b/.azuredevops/components/omnitrace.yml
@@ -112,6 +112,9 @@ jobs:
         -DOMNITRACE_USE_MPI=ON
         -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
       multithreadFlag: -- -j32
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
+    parameters:
+      componentName: omnitrace
   - task: Bash@3
     displayName: Remove ROCm binaries from PATH
     inputs:


### PR DESCRIPTION
omnitrace tests don't require a GPU and its ctest files aren't packaged, so it runs tests in the build step. 

Build logs (45 min): https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=9072&view=results