### PR TITLE
External CI: Fix rocPyDecode wheel creation

### DIFF
--- a/.azuredevops/components/rocPyDecode.yml
+++ b/.azuredevops/components/rocPyDecode.yml
@@ -97,7 +97,10 @@ jobs:
     displayName: Create wheel file
     inputs:
       targetType: inline
-      script: python setup.py bdist_wheel
+      script: |
+        export ROCM_PATH=$(Agent.BuildDirectory)/rocm
+        export HIP_INCLUDE_DIRS=$(Agent.BuildDirectory)/rocm/include/hip
+        python3 setup.py bdist_wheel
       workingDirectory: $(Build.SourcesDirectory)
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-prepare-package.yml
     parameters:


### PR DESCRIPTION
- Set values for expected environment variables.
- Accompanying changes required in rocPyDecode repo. Pull request will be made.
- [Pipeline build log](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=9371&view=results) where wheel creation works. Testing was cancelled to save resources. 