### PR TITLE
Update bitsandbytes default branch in docs

### DIFF
--- a/docs/how-to/llm-fine-tuning-optimization/model-quantization.rst
+++ b/docs/how-to/llm-fine-tuning-optimization/model-quantization.rst
@@ -181,7 +181,7 @@ Installing bitsandbytes
       # Clone the github repo
       git clone --recurse https://github.com/ROCm/bitsandbytes.git
       cd bitsandbytes
-      git checkout rocm_enabled
+      git checkout rocm_enabled_multi_backend
 
       # Install dependencies 
       pip install -r requirements-dev.txt

--- a/docs/how-to/llm-fine-tuning-optimization/single-gpu-fine-tuning-and-inference.rst
+++ b/docs/how-to/llm-fine-tuning-optimization/single-gpu-fine-tuning-and-inference.rst
@@ -91,7 +91,7 @@ Setting up the base implementation environment
       # Use -DBNB_ROCM_ARCH to target a specific GPU architecture.
       git clone --recurse https://github.com/ROCm/bitsandbytes.git
       cd bitsandbytes
-      git checkout rocm_enabled
+      git checkout rocm_enabled_multi_backend
       pip install -r requirements-dev.txt
       cmake -DBNB_ROCM_ARCH="gfx942" -DCOMPUTE_BACKEND=hip -S .
       python setup.py install


### PR DESCRIPTION
Users should checkout `rocm_enabled_multi_backend` by default instead of `rocm_enabled` now.

https://github.com/ROCm/bitsandbytes