### PR TITLE
Documentation: Add reference to precision-support floating-point types

### DIFF
--- a/docs/reference/precision-support.rst
+++ b/docs/reference/precision-support.rst
@@ -41,6 +41,8 @@ together with their corresponding HIP type and a short description.
       - ``int64_t``, ``uint64_t``
       - A signed or unsigned 64-bit integer
 
+.. _precision_support_floating_point_types:
+
 Floating-point types
 ==========================================
 


### PR DESCRIPTION
Very small PR to add a ref to the precision support table to link to it from other pages
Needed for https://github.com/ROCm/HIP/pull/3574