### PR TITLE
External CI: use Boost template for MIOpen

### DIFF
--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -16,6 +16,7 @@ parameters:
     - libgtest-dev
     - libsqlite3-dev
     - libstdc++-12-dev
+    - libzstd-dev
     - ninja-build
     - nlohmann-json3-dev
     - python3-pip
@@ -79,19 +80,12 @@ jobs:
     parameters:
       aptPackages: ${{ parameters.aptPackages }}
       pipModules: ${{ parameters.pipModules }}
-  # The default boost library from apt is 1.74, which does not satisfy MIOpen's build requirement (1.79+)
-  # Upgrade boost from apt by following https://launchpad.net/~mhier/+archive/ubuntu/libboost-latest
-  - task: Bash@3
-    displayName: 'Install Boost 1.83'
-    inputs:
-      targetType: inline
-      script: |
-        sudo add-apt-repository ppa:mhier/libboost-latest -y
-        sudo apt-get --yes install libboost1.83-dev libboost-system1.83-dev libboost-filesystem1.83-dev
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
     parameters:
       checkoutRepo: ${{ parameters.checkoutRepo }}
+  # The default boost library from apt is 1.74, which does not satisfy MIOpen's build requirement (1.79+)
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-boost.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
     parameters:
       dependencyList: ${{ parameters.rocmDependencies }}
@@ -107,7 +101,8 @@ jobs:
       extraBuildFlags: >-
         -DMIOPEN_BACKEND=HIP
         -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
-        -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
+        -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/boost
+        -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
         -DMIOPEN_ENABLE_AI_KERNEL_TUNING=OFF
         -DMIOPEN_ENABLE_AI_IMMED_MODE_FALLBACK=OFF
         -DCMAKE_BUILD_TYPE=Release
@@ -136,17 +131,12 @@ jobs:
     parameters:
       aptPackages: ${{ parameters.aptPackages }}
       pipModules: ${{ parameters.pipModules }}
-  - task: Bash@3
-    displayName: 'Install Boost 1.83'
-    inputs:
-      targetType: inline
-      script: |
-        sudo add-apt-repository ppa:mhier/libboost-latest -y
-        sudo apt-get --yes install libboost1.83-dev libboost-system1.83-dev libboost-filesystem1.83-dev
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
     parameters:
       checkoutRepo: ${{ parameters.checkoutRepo }}
+  # The default boost library from apt is 1.74, which does not satisfy MIOpen's build requirement (1.79+)
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-boost.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-aqlprofile.yml
     parameters:
       ${{ if eq(parameters.checkoutRef, '') }}:
@@ -198,7 +188,7 @@ jobs:
     displayName: 'MIOpen Test CMake Flags'
     inputs:
       cmakeArgs: >-
-        -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Build.SourcesDirectory)/bin;$(Build.SourcesDirectory)/cget/cget/pkg/Dobiasd__FunctionalPlus/install
+        -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Build.SourcesDirectory)/bin;$(Build.SourcesDirectory)/cget/cget/pkg/Dobiasd__FunctionalPlus/install;$(Agent.BuildDirectory)/boost
         -DCMAKE_INSTALL_PREFIX=$(Agent.BuildDirectory)/rocm
         -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
         -DCMAKE_C_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang
@@ -216,12 +206,3 @@ jobs:
       testParameters: ''
       reloadAMDGPU: true
       testPublishResults: false
-  - task: Bash@3
-    condition: always()
-    displayName: Clean up Boost 1.83
-    inputs:
-      targetType: inline
-      script: |
-        sudo apt -y autoremove libboost1.83-dev libboost-system1.83-dev libboost-filesystem1.83-dev
-        sudo add-apt-repository --remove ppa:mhier/libboost-latest -y
-        sudo apt update

--- a/.azuredevops/templates/steps/dependencies-boost.yml
+++ b/.azuredevops/templates/steps/dependencies-boost.yml
@@ -1,60 +1,31 @@
-# download and install rocm dependencies through pipeline builds in the project
-# REQUIRED
-parameters:
-- name: dependencyList
-  type: object
-  default: []
-- name: dependencySource
-  type: string
-  default: staging
-  values:
-    - staging
-    - mainline
-    - tag-builds
-    - fixed
-- name: extractToMnt
-  type: boolean
-  default: false
-# required values for fixed selection
-- name: fixedPipelineIdentifier
-  type: string
-  default: 0
-- name: fixedComponentName
-  type: string
-  default: ''
-- name: latestFromBranch
-  type: boolean
-  default: true
-
 steps:
-# fixed case only accepts one component at a time, so no array input
 - task: DownloadPipelineArtifact@2
-  displayName: Download ${{ parameters.componentName }}
+  displayName: Download Boost
   inputs:
     buildType: specific
     project: ROCm-CI
     definition: $(BOOST_DEPENDENCY_PIPELINE_ID)
     targetPath: $(Pipeline.Workspace)/d
 - task: ExtractFiles@1
-  displayName: Extract ${{ parameters.componentName }}
+  displayName: Extract Boost
   inputs:
     archiveFilePatterns: '$(Pipeline.Workspace)/d/**/*.tar.gz'
     destinationFolder: $(Agent.BuildDirectory)/boost
     cleanDestinationFolder: true
     overwriteExistingFiles: true
 - task: DeleteFiles@1
-  displayName: Cleanup Compressed ${{ parameters.componentName }}
+  displayName: Cleanup Compressed Boost
   inputs:
     SourceFolder: $(Pipeline.Workspace)/d
     Contents: '**/*.tar.gz'
     RemoveDotFiles: true
 - task: Bash@3
-  displayName: 'List noost files'
+  displayName: 'List Boost files'
   inputs:
     targetType: inline
     script: ls -1R $(Agent.BuildDirectory)/boost
 - task: Bash@3
-  displayName: 'Link boost shared libraries'
+  displayName: 'Link Boost shared libraries'
   inputs:
     targetType: inline
     script: |


### PR DESCRIPTION
Updates MIOpen pipeline to use the Boost template, and removes some unused parameters from the Boost template.

Build log:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=10197&view=results