### PR TITLE
External CI: MIOpen parse test results

### DIFF
--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -64,57 +64,57 @@ parameters:
     - roctracer
 
 jobs:
-- job: MIOpen
-  variables:
-  - group: common
-  - template: /.azuredevops/variables-global.yml
-  pool: ${{ variables.MEDIUM_BUILD_POOL }}
-  workspace:
-    clean: all
-  strategy:
-    matrix:
-      gfx942:
-        JOB_GPU_TARGET: gfx942
-  steps:
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
-    parameters:
-      aptPackages: ${{ parameters.aptPackages }}
-      pipModules: ${{ parameters.pipModules }}
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
-    parameters:
-      checkoutRepo: ${{ parameters.checkoutRepo }}
-  # The default boost library from apt is 1.74, which does not satisfy MIOpen's build requirement (1.79+)
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-boost.yml
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
-    parameters:
-      dependencyList: ${{ parameters.rocmDependencies }}
-      gpuTarget: $(JOB_GPU_TARGET)
-      # CI case: download latest default branch build
-      ${{ if eq(parameters.checkoutRef, '') }}:
-        dependencySource: staging
-      # manual build case: triggered by ROCm/ROCm repo
-      ${{ elseif ne(parameters.checkoutRef, '') }}:
-        dependencySource: tag-builds
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
-    parameters:
-      extraBuildFlags: >-
-        -DMIOPEN_BACKEND=HIP
-        -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
-        -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/boost
-        -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
-        -DMIOPEN_ENABLE_AI_KERNEL_TUNING=OFF
-        -DMIOPEN_ENABLE_AI_IMMED_MODE_FALLBACK=OFF
-        -DCMAKE_BUILD_TYPE=Release
-        -DBUILD_TESTING=ON
-        -GNinja
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
-    parameters:
-      gpuTarget: $(JOB_GPU_TARGET)
+# - job: MIOpen
+#   variables:
+#   - group: common
+#   - template: /.azuredevops/variables-global.yml
+#   pool: ${{ variables.MEDIUM_BUILD_POOL }}
+#   workspace:
+#     clean: all
+#   strategy:
+#     matrix:
+#       gfx942:
+#         JOB_GPU_TARGET: gfx942
+#   steps:
+#   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
+#     parameters:
+#       aptPackages: ${{ parameters.aptPackages }}
+#       pipModules: ${{ parameters.pipModules }}
+#   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+#   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+#     parameters:
+#       checkoutRepo: ${{ parameters.checkoutRepo }}
+#   # The default boost library from apt is 1.74, which does not satisfy MIOpen's build requirement (1.79+)
+#   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-boost.yml
+#   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
+#     parameters:
+#       dependencyList: ${{ parameters.rocmDependencies }}
+#       gpuTarget: $(JOB_GPU_TARGET)
+#       # CI case: download latest default branch build
+#       ${{ if eq(parameters.checkoutRef, '') }}:
+#         dependencySource: staging
+#       # manual build case: triggered by ROCm/ROCm repo
+#       ${{ elseif ne(parameters.checkoutRef, '') }}:
+#         dependencySource: tag-builds
+#   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+#     parameters:
+#       extraBuildFlags: >-
+#         -DMIOPEN_BACKEND=HIP
+#         -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
+#         -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/boost
+#         -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
+#         -DMIOPEN_ENABLE_AI_KERNEL_TUNING=OFF
+#         -DMIOPEN_ENABLE_AI_IMMED_MODE_FALLBACK=OFF
+#         -DCMAKE_BUILD_TYPE=Release
+#         -DBUILD_TESTING=ON
+#         -GNinja
+#   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
+#     parameters:
+#       gpuTarget: $(JOB_GPU_TARGET)
 
 - job: MIOpen_testing
-  dependsOn: MIOpen
-  condition: and(succeeded(), eq(variables.ENABLE_GFX942_TESTS, 'true'))
+  # dependsOn: MIOpen
+  # condition: and(succeeded(), eq(variables.ENABLE_GFX942_TESTS, 'true'))
   variables:
   - group: common
   - template: /.azuredevops/variables-global.yml
@@ -139,17 +139,17 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-boost.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-aqlprofile.yml
     parameters:
-      ${{ if eq(parameters.checkoutRef, '') }}:
+      ${{ if eq(parameters.checkoutRef, 'develop') }}:
         dependencySource: staging
-      ${{ elseif ne(parameters.checkoutRef, '') }}:
+      ${{ elseif ne(parameters.checkoutRef, 'develop') }}:
         dependencySource: tag-builds
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
     parameters:
       dependencyList: ${{ parameters.rocmTestDependencies }}
       gpuTarget: $(JOB_GPU_TARGET)
-      ${{ if eq(parameters.checkoutRef, '') }}:
+      ${{ if eq(parameters.checkoutRef, 'develop') }}:
         dependencySource: staging
-      ${{ elseif ne(parameters.checkoutRef, '') }}:
+      ${{ elseif ne(parameters.checkoutRef, 'develop') }}:
         dependencySource: tag-builds
 # MIOpen depends on a specific version of frugally-deep which is forked here: https://github.com/ROCm/frugally-deep
 # https://github.com/ROCm/frugally-deep/blob/master/INSTALL.md
@@ -199,10 +199,13 @@ jobs:
         -DMIOPEN_USE_MLIR=ON
         -DMIOPEN_GPU_SYNC=OFF
         ..
+  - task: Bash@3
+    displayName: 'MIOpen Test Build'
+    inputs:
+      targetType: inline
+      script: |
+        cmake --build . --target tests
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
     parameters:
       componentName: MIOpen
-      testExecutable: 'CTEST_PARALLEL_LEVEL=4 make -j$(nproc) check'
-      testParameters: ''
       reloadAMDGPU: true
-      testPublishResults: false

--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -204,7 +204,7 @@ jobs:
     inputs:
       targetType: inline
       script: |
-        cmake --build . --target tests
+        cmake --build . --target tests -- -j$(nproc)
       workingDirectory: $(Build.SourcesDirectory)/build
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
     parameters:

--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -64,57 +64,57 @@ parameters:
     - roctracer
 
 jobs:
-# - job: MIOpen
-#   variables:
-#   - group: common
-#   - template: /.azuredevops/variables-global.yml
-#   pool: ${{ variables.MEDIUM_BUILD_POOL }}
-#   workspace:
-#     clean: all
-#   strategy:
-#     matrix:
-#       gfx942:
-#         JOB_GPU_TARGET: gfx942
-#   steps:
-#   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
-#     parameters:
-#       aptPackages: ${{ parameters.aptPackages }}
-#       pipModules: ${{ parameters.pipModules }}
-#   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
-#   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
-#     parameters:
-#       checkoutRepo: ${{ parameters.checkoutRepo }}
-#   # The default boost library from apt is 1.74, which does not satisfy MIOpen's build requirement (1.79+)
-#   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-boost.yml
-#   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
-#     parameters:
-#       dependencyList: ${{ parameters.rocmDependencies }}
-#       gpuTarget: $(JOB_GPU_TARGET)
-#       # CI case: download latest default branch build
-#       ${{ if eq(parameters.checkoutRef, '') }}:
-#         dependencySource: staging
-#       # manual build case: triggered by ROCm/ROCm repo
-#       ${{ elseif ne(parameters.checkoutRef, '') }}:
-#         dependencySource: tag-builds
-#   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
-#     parameters:
-#       extraBuildFlags: >-
-#         -DMIOPEN_BACKEND=HIP
-#         -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
-#         -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/boost
-#         -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
-#         -DMIOPEN_ENABLE_AI_KERNEL_TUNING=OFF
-#         -DMIOPEN_ENABLE_AI_IMMED_MODE_FALLBACK=OFF
-#         -DCMAKE_BUILD_TYPE=Release
-#         -DBUILD_TESTING=ON
-#         -GNinja
-#   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
-#     parameters:
-#       gpuTarget: $(JOB_GPU_TARGET)
+- job: MIOpen
+  variables:
+  - group: common
+  - template: /.azuredevops/variables-global.yml
+  pool: ${{ variables.MEDIUM_BUILD_POOL }}
+  workspace:
+    clean: all
+  strategy:
+    matrix:
+      gfx942:
+        JOB_GPU_TARGET: gfx942
+  steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
+      pipModules: ${{ parameters.pipModules }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+    parameters:
+      checkoutRepo: ${{ parameters.checkoutRepo }}
+  # The default boost library from apt is 1.74, which does not satisfy MIOpen's build requirement (1.79+)
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-boost.yml
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
+    parameters:
+      dependencyList: ${{ parameters.rocmDependencies }}
+      gpuTarget: $(JOB_GPU_TARGET)
+      # CI case: download latest default branch build
+      ${{ if eq(parameters.checkoutRef, '') }}:
+        dependencySource: staging
+      # manual build case: triggered by ROCm/ROCm repo
+      ${{ elseif ne(parameters.checkoutRef, '') }}:
+        dependencySource: tag-builds
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      extraBuildFlags: >-
+        -DMIOPEN_BACKEND=HIP
+        -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
+        -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/boost
+        -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
+        -DMIOPEN_ENABLE_AI_KERNEL_TUNING=OFF
+        -DMIOPEN_ENABLE_AI_IMMED_MODE_FALLBACK=OFF
+        -DCMAKE_BUILD_TYPE=Release
+        -DBUILD_TESTING=ON
+        -GNinja
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
+    parameters:
+      gpuTarget: $(JOB_GPU_TARGET)
 
 - job: MIOpen_testing
-  # dependsOn: MIOpen
-  # condition: and(succeeded(), eq(variables.ENABLE_GFX942_TESTS, 'true'))
+  dependsOn: MIOpen
+  condition: and(succeeded(), eq(variables.ENABLE_GFX942_TESTS, 'true'))
   variables:
   - group: common
   - template: /.azuredevops/variables-global.yml
@@ -139,17 +139,17 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-boost.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-aqlprofile.yml
     parameters:
-      ${{ if eq(parameters.checkoutRef, 'develop') }}:
+      ${{ if eq(parameters.checkoutRef, '') }}:
         dependencySource: staging
-      ${{ elseif ne(parameters.checkoutRef, 'develop') }}:
+      ${{ elseif ne(parameters.checkoutRef, '') }}:
         dependencySource: tag-builds
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
     parameters:
       dependencyList: ${{ parameters.rocmTestDependencies }}
       gpuTarget: $(JOB_GPU_TARGET)
-      ${{ if eq(parameters.checkoutRef, 'develop') }}:
+      ${{ if eq(parameters.checkoutRef, '') }}:
         dependencySource: staging
-      ${{ elseif ne(parameters.checkoutRef, 'develop') }}:
+      ${{ elseif ne(parameters.checkoutRef, '') }}:
         dependencySource: tag-builds
 # MIOpen depends on a specific version of frugally-deep which is forked here: https://github.com/ROCm/frugally-deep
 # https://github.com/ROCm/frugally-deep/blob/master/INSTALL.md

--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -205,6 +205,7 @@ jobs:
       targetType: inline
       script: |
         cmake --build . --target tests
+      workingDirectory: $(Build.SourcesDirectory)/build
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
     parameters:
       componentName: MIOpen


### PR DESCRIPTION
Changes the test build target from `check` to `tests`, which doesn't run ctest during the build process. This allows us to use the default test template and for Azure to parse the test results.

Build log:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=10307&view=results