### PR TITLE
docs: Remove invalid amd_iommu=on parameter

### DIFF
--- a/docs/how-to/system-optimization/mi100.md
+++ b/docs/how-to/system-optimization/mi100.md
@@ -342,8 +342,8 @@ If SMT is enabled by setting "CCD/Core/Thread Enablement > SMT Control" to
 (logical) cores of the system:
 
 * In the server BIOS, set IOMMU to "Enabled".
-* When configuring the Grub boot loader, add the following arguments for the
-  Linux kernel: `amd_iommu=on iommu=pt`
+* When configuring the Grub boot loader, add the following argument for the
+  Linux kernel: `iommu=pt`
 * Update Grub to use the modified configuration:
 
   ```shell
@@ -355,7 +355,7 @@ If SMT is enabled by setting "CCD/Core/Thread Enablement > SMT Control" to
 
   ```none
   [...]
-  [   0.000000] Kernel command line: [...] amd_iommu=on iommu=pt
+  [   0.000000] Kernel command line: [...] iommu=pt
      [...]
   ```
 

--- a/docs/how-to/system-optimization/mi200.md
+++ b/docs/how-to/system-optimization/mi200.md
@@ -327,8 +327,8 @@ If SMT is enabled by setting "CCD/Core/Thread Enablement > SMT Control" to
 (logical) cores of the system:
 
 * In the server BIOS, set IOMMU to "Enabled".
-* When configuring the Grub boot loader, add the following arguments for the
-  Linux kernel: `amd_iommu=on iommu=pt`
+* When configuring the Grub boot loader, add the following argument for the
+  Linux kernel: `iommu=pt`
 * Update Grub to use the modified configuration:
 
   ```shell
@@ -340,7 +340,7 @@ If SMT is enabled by setting "CCD/Core/Thread Enablement > SMT Control" to
 
   ```none
   [...]
-  [   0.000000] Kernel command line: [...] amd_iommu=on iommu=pt
+  [   0.000000] Kernel command line: [...] iommu=pt
      [...]
   ```
 

--- a/docs/how-to/system-optimization/mi300x.rst
+++ b/docs/how-to/system-optimization/mi300x.rst
@@ -299,7 +299,7 @@ For a system that has AMD host CPUs add this to ``GRUB_CMDLINE_LINUX``:
 
 .. code-block:: text
 
-   amd_iommu=on iommu=pt
+   iommu=pt
 
 Otherwise, if the system has Intel host CPUs add this instead to
 ``GRUB_CMDLINE_LINUX``:
@@ -500,7 +500,7 @@ If SMT is enabled by setting ``CCD/Core/Thread Enablement > SMT Control`` to
 
 #. In the server BIOS, set IOMMU to ``Enabled``.
 
-#. When configuring the GRUB boot loader, add the following arguments for the Linux kernel: ``amd_iommu=on iommu=pt``.
+#. When configuring the GRUB boot loader, add the following argument for the Linux kernel: ``iommu=pt``.
 
 #. Update GRUB.
 
@@ -515,7 +515,7 @@ If SMT is enabled by setting ``CCD/Core/Thread Enablement > SMT Control`` to
 .. code-block:: shell
 
    [...]
-   [   0.000000] Kernel command line: [...] amd_iommu=on iommu=pt
+   [   0.000000] Kernel command line: [...] iommu=pt
    [...]
 
 Once the system is properly configured, ROCm software can be

--- a/docs/how-to/system-optimization/w6000-v620.md
+++ b/docs/how-to/system-optimization/w6000-v620.md
@@ -111,7 +111,7 @@ sudo virsh net-start default /*to enable Virtual network by default
 Enable input-output memory management unit (IOMMU) in GRUB settings by adding the following line to `/etc/default/grub`:
 
 ```none
-GRUB_CMDLINE_LINUX_DEFAULT="quiet splash amd_iommu=on" for AMD CPU
+GRUB_CMDLINE_LINUX_DEFAULT="quiet splash" for AMD CPU
 ```
 
 Update grub and reboot

--- a/tools/autotag/templates/highlights/5.3.0.md
+++ b/tools/autotag/templates/highlights/5.3.0.md
@@ -184,5 +184,5 @@ clinfo, and HelloWord.cl and cause a system crash.
 * IRQ remapping does not support X2APIC mode
 * NMI error
 
-Workaround: To avoid the system crash, add `amd_iommu=on iommu=pt` as the kernel bootparam, as
+Workaround: To avoid the system crash, add `iommu=pt` as the kernel bootparam, as
 indicated in the warning message.


### PR DESCRIPTION
- #3919 

Per kernel-parameters.txt, there is no "on" option for amd_iommu. While intel_iommu has it, amd_iommu is automatically on unless specified otherwise. For more info, see these 2 links:

https://www.kernel.org/doc/Documentation/admin-guide/kernel-parameters.txt https://github.com/torvalds/linux/blob/75aa74d52f43e75d0beb20572f98529071b700e5/drivers/iommu/amd/init.c#L3481

Signed-off-by: Kent Russell <kent.russell@amd.com>
(cherry picked from commit 74333b667d34ce9d90726572533b28059f3fe5b6)