### PR TITLE
External CI: hipBLASLt build now requires python packaging module

### DIFF
--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -22,6 +22,7 @@ parameters:
   type: object
   default:
     - joblib
+    - packaging
 - name: rocmDependencies
   type: object
   default:
@@ -164,6 +165,7 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
     parameters:
       aptPackages: ${{ parameters.aptPackages }}
+      pipModules: ${{ parameters.pipModules }}
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
     parameters:


### PR DESCRIPTION
- [Catalyst](https://github.com/ROCm/hipBLASLt/pull/1250/files#diff-fee2e6f068b33fca3a1dc49392de8848dbf05c3f4632b680abb1052523e5a30fR35)
- [Failing Build Log After Catalyst](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=10567&view=results)
- [Passing Build Log With Catalyst and This PR](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=10574&view=results)