### PR TITLE
External CI: disable rocMLIR tests

### DIFF
--- a/.azuredevops/components/rocMLIR.yml
+++ b/.azuredevops/components/rocMLIR.yml
@@ -68,7 +68,7 @@ jobs:
 # compiling and running test on the test system together
 - job: rocMLIR_testing
   dependsOn: rocMLIR
-  condition: and(succeeded(), eq(variables.ENABLE_GFX942_TESTS, 'true'))
+  condition: and(succeeded(), eq(variables.ENABLE_GFX942_TESTS, 'true'), false)
   variables:
   - group: common
   - template: /.azuredevops/variables-global.yml

--- a/.azuredevops/components/roctracer.yml
+++ b/.azuredevops/components/roctracer.yml
@@ -75,6 +75,7 @@ jobs:
         -DCMAKE_MODULE_PATH=$(Agent.BuildDirectory)/rocm/lib/cmake/hip
         -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
         -DGPU_TARGETS=$(JOB_GPU_TARGET)
+        -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
         -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
     parameters:


### PR DESCRIPTION
rocMLIR tests are failing and leaking processes, leaving the system in a bad state. Skipping over the tests for now.

Also adds `AMDGPU_TARGETS` flag to roctracer to fix a build warning.

Sample rocMLIR failure:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=10579&view=results
Sample rocRAND hang due to prior rocMLIR test:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=10522&view=results