### PR TITLE
Improve consistency of the gpu-arch-specs table.

### DIFF
--- a/docs/reference/gpu-arch-specs.rst
+++ b/docs/reference/gpu-arch-specs.rst
@@ -772,3 +772,7 @@ scalar instructions.
 **GCD**
 
 Graphics Compute Die.
+
+**XCD**
+
+Accelerator Complex Die.

--- a/docs/reference/gpu-arch-specs.rst
+++ b/docs/reference/gpu-arch-specs.rst
@@ -37,11 +37,11 @@ For more information about ROCm hardware compatibility, see the ROCm `Compatibil
           - CDNA3
           - gfx941 or gfx942
           - 192
-          - 304
+          - 304 (38 per XCD)
           - 64
           - 64
           - 256
-          - 32
+          - 32 (4 per XCD)
           - 32
           - 16 per 2 CUs
           - 64 per 2 CUs
@@ -52,11 +52,11 @@ For more information about ROCm hardware compatibility, see the ROCm `Compatibil
           - CDNA3
           - gfx940 or gfx942
           - 128
-          - 228
+          - 228 (38 per XCD)
           - 64
           - 64
           - 256
-          - 24
+          - 24 (4 per XCD)
           - 32
           - 16 per 2 CUs
           - 64 per 2 CUs
@@ -82,7 +82,7 @@ For more information about ROCm hardware compatibility, see the ROCm `Compatibil
           - CDNA2
           - gfx90a
           - 128
-          - 208
+          - 208 (104 per GCD)
           - 64
           - 64
           -


### PR DESCRIPTION
There was inconsistency in the CU count where 250X lists per GCD, but 250 does not. In keeping with the per GCD convention, it would make sense to list CU and L2 cacher per XCD for MI300 as well.