### PR TITLE
External CI: pytorch pipeline updates

### DIFF
--- a/.azuredevops/nightly/pytorch.yml
+++ b/.azuredevops/nightly/pytorch.yml
@@ -68,7 +68,7 @@ parameters:
   default:
     - cmake
     - astunparse
-    - expecttest!=0.2.0
+    - expecttest>=0.2.1
     - hypothesis
     - numpy
     - psutil
@@ -85,7 +85,8 @@ parameters:
     - lintrunner
     - ninja
     - packaging
-    - optree>=0.12.0
+    - optree>=0.13.0
+    - click>=8.0.3
   # list for vision
     - auditwheel
     - future
@@ -232,8 +233,10 @@ jobs:
     displayName: git clone pytorch builder
     inputs:
       targetType: inline
-      script: git clone https://github.com/pytorch/builder.git --depth=1 --recurse-submodules
-      workingDirectory: $(Build.SourcesDirectory)/pytorch
+      script: |
+        git clone https://github.com/pytorch/builder.git --depth=1 --recurse-submodules
+        sudo ln -s $(Build.SourcesDirectory)/builder /builder
+      workingDirectory: $(Build.SourcesDirectory)
   - task: Bash@3
     displayName: Install patchelf
     inputs:


### PR DESCRIPTION
To support recent upstream changes and issues observed.

These changes can be seen to unblock execution in this job: https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=11015&view=results

However, recent stack changes seem to cause tests to hang, which is not caused by pipeline code.

Full build job functionality is dependent on my upstream pytorch PR to merge, as the linked jobs had an extra block to force CK submodule to update. My pending PR changes the submodule upstream.