### PR TITLE
External CI: Add aqlprofile to Tensile test dependencies

### DIFF
--- a/.azuredevops/components/Tensile.yml
+++ b/.azuredevops/components/Tensile.yml
@@ -105,6 +105,12 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
     parameters:
       checkoutRepo: ${{ parameters.checkoutRepo }}
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-aqlprofile.yml
+    parameters:
+      ${{ if eq(parameters.checkoutRef, '') }}:
+        dependencySource: staging
+      ${{ elseif ne(parameters.checkoutRef, '') }}:
+        dependencySource: tag-builds
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
     parameters:
       dependencyList: ${{ parameters.rocmDependencies }}


### PR DESCRIPTION
[Log output](https://dev.azure.com/rocm-ci/ROCm-CI/_build/results?buildId=11100&view=logs&j=8ffe2db8-e69f-5c49-4c8e-6ac009c1283b&t=a74b2696-0bdd-5ef0-3840-ebc0a84dd54e) shows it is looking for aqlprofile during test execution.