### PR TITLE
External CI: various fixes

### DIFF
--- a/.azuredevops/components/AMDMIGraphX.yml
+++ b/.azuredevops/components/AMDMIGraphX.yml
@@ -189,9 +189,9 @@ jobs:
         -DMIGRAPHX_ENABLE_C_API_TEST=ON
         ..
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
-  - task: Bash@3
-    displayName: Build and run MIGraphX tests
-    inputs:
-      targetType: inline
-      workingDirectory: build
-      script: make -j$(nproc) check
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
+    parameters:
+      componentName: AMDMIGraphX
+      testExecutable: make
+      testParameters: -j$(nproc) check
+      testPublishResults: false

--- a/.azuredevops/components/ROCR-Runtime.yml
+++ b/.azuredevops/components/ROCR-Runtime.yml
@@ -107,6 +107,7 @@ jobs:
       runRocminfo: false
   - task: Bash@3
     displayName: Build kfdtest
+    continueOnError: true
     inputs:
       targetType: 'inline'
       workingDirectory: $(Build.SourcesDirectory)/libhsakmt/tests/kfdtest
@@ -122,6 +123,7 @@ jobs:
       testDir: $(Build.SourcesDirectory)/libhsakmt/tests/kfdtest/scripts
   - task: Bash@3
     displayName: Build rdmatest app
+    continueOnError: true
     inputs:
       targetType: 'inline'
       workingDirectory: $(Build.SourcesDirectory)/libhsakmt/tests/rdma/simple/app
@@ -130,6 +132,7 @@ jobs:
         cmake --build .
   - task: Bash@3
     displayName: Build rdmatest driver
+    continueOnError: true
     inputs:
       targetType: 'inline'
       workingDirectory: $(Build.SourcesDirectory)/libhsakmt/tests/rdma/simple/drv
@@ -139,6 +142,7 @@ jobs:
         RDMA_HEADER_DIR=/usr/src/amdgpu-*/include make all
   - task: Bash@3
     displayName: Install rdmatest driver
+    continueOnError: true
     inputs:
       targetType: 'inline'
       workingDirectory: $(Build.SourcesDirectory)/libhsakmt/tests/rdma/simple/drv
@@ -154,6 +158,7 @@ jobs:
       testPublishResults: false
   - task: Bash@3
     displayName: Build rocrtst
+    continueOnError: true
     inputs:
       targetType: 'inline'
       workingDirectory: $(Build.SourcesDirectory)/rocrtst/suites/test_common

--- a/.azuredevops/components/ROCmValidationSuite.yml
+++ b/.azuredevops/components/ROCmValidationSuite.yml
@@ -13,6 +13,7 @@ parameters:
     - libyaml-cpp-dev
     - libpci-dev
     - libpci3
+    - libgst-dev
     - libgtest-dev
     - git
 - name: rocmDependencies

--- a/.azuredevops/components/omnitrace.yml
+++ b/.azuredevops/components/omnitrace.yml
@@ -40,6 +40,7 @@ parameters:
 - name: rocmDependencies
   type: object
   default:
+    - aomp
     - clr
     - llvm-project
     - rccl


### PR DESCRIPTION
- Changes AMDMIGraphX to use the test template
- Sets `continueOnError` to ROCR-Runtime test build steps, so other tests can continue to run if one fails
- Adds `libgst-dev` to RVS deps
- Adds aomp to omnitrace deps