### PR TITLE
External CI: rocprofiler-compute pipeline files

### DIFF
--- a/.azuredevops/components/rocprofiler-compute.yml
+++ b/.azuredevops/components/rocprofiler-compute.yml
@@ -46,7 +46,7 @@ parameters:
     - roctracer
 
 jobs:
-- job: omniperf
+- job: rocprofiler_compute
   variables:
   - group: common
   - template: /.azuredevops/variables-global.yml
@@ -88,8 +88,8 @@ jobs:
     parameters:
       gpuTarget: $(JOB_GPU_TARGET)
 
-- job: omniperf_testing
-  dependsOn: omniperf
+- job: rocprofiler_compute_testing
+  dependsOn: rocprofiler_compute
   condition: and(succeeded(), eq(variables.ENABLE_GFX942_TESTS, 'true'), not(containsValue(split(variables.DISABLED_GFX942_TESTS, ','), variables['Build.DefinitionName'])))
   variables:
   - group: common
@@ -151,9 +151,9 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
     parameters:
-      componentName: omniperf
-      testDir: $(Build.BinariesDirectory)/libexec/omniperf
-      testExecutable: export OMNIPERF_ARCH_OVERRIDE="MI300X"; ctest
+      componentName: rocprofiler-compute
+      testDir: $(Build.BinariesDirectory)/libexec/rocprofiler-compute
+      testExecutable: export ROCPROFCOMPUTE_ARCH_OVERRIDE="MI300X"; ctest
   - task: Bash@3
     displayName: Remove ROCm binaries from PATH
     inputs:

--- a/.azuredevops/tag-builds/rocprofiler-compute.yml
+++ b/.azuredevops/tag-builds/rocprofiler-compute.yml
@@ -16,14 +16,14 @@ resources:
   - repository: release_repo
     type: github
     endpoint: ROCm
-    name: ROCm/omniperf
+    name: ROCm/rocprofiler-compute
     ref: ${{ parameters.checkoutRef }}
 
 trigger: none
 pr: none
 
 jobs:
-  - template: ${{ variables.CI_COMPONENT_PATH }}/omniperf.yml
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rocprofiler-compute.yml
     parameters:
       checkoutRepo: release_repo
       checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/templates/steps/artifact-download.yml
+++ b/.azuredevops/templates/steps/artifact-download.yml
@@ -70,6 +70,7 @@ parameters:
     rocm_smi_lib: amd-staging
     rocPRIM: develop
     rocprofiler: amd-staging
+    rocprofiler-compute: amd-staging
     rocprofiler-register: amd-staging
     rocprofiler-sdk: amd-staging
     rocprofiler-systems: amd-staging
@@ -131,6 +132,7 @@ parameters:
     rocm_smi_lib: amd-mainline
     rocPRIM: mainline
     rocprofiler: amd-master
+    rocprofiler-compute: amd-mainline
     rocprofiler-register: amd-mainline
     rocprofiler-sdk: amd-mainline
     rocprofiler-systems: amd-mainline

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -186,6 +186,7 @@ parameters:
     - rocFFT
     - rocm-examples
     - rocPRIM
+    - rocprofiler-compute
     - rocprofiler-sdk
     - rocprofiler-systems
     - rocprofiler


### PR DESCRIPTION
Renamed pipeline files, added staging and mainline branch names, and gfx download filters for omniperf -> rocprofiler-compute.

