### PR TITLE
External CI: disable reload AMDGPU

### DIFF
--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -210,4 +210,3 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
     parameters:
       componentName: MIOpen
-      reloadAMDGPU: true

--- a/.azuredevops/components/hip-tests.yml
+++ b/.azuredevops/components/hip-tests.yml
@@ -136,7 +136,6 @@ jobs:
     parameters:
       componentName: hip_tests
       testDir: $(Agent.BuildDirectory)/rocm/share/hip
-      reloadAMDGPU: true
   - task: Bash@3
     displayName: Clean up symlink
     inputs:

--- a/.azuredevops/components/rocAL.yml
+++ b/.azuredevops/components/rocAL.yml
@@ -224,7 +224,6 @@ jobs:
     parameters:
       componentName: rocAL
       testDir: rocAL-tests
-      reloadAMDGPU: true
   - task: Bash@3
     displayName: Clean up libjpeg-turbo
     inputs:

--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -166,4 +166,3 @@ jobs:
     parameters:
       componentName: rocm-examples
       testDir: $(Build.SourcesDirectory)/build
-      reloadAMDGPU: true


### PR DESCRIPTION
Disables reloading AMDGPU for the few components which had it. It doesn't work in Docker, and the Docker agents should not need this anyways.