### PR TITLE
External CI: add roctracer to rocBLAS deps

### DIFF
--- a/.azuredevops/components/rocBLAS.yml
+++ b/.azuredevops/components/rocBLAS.yml
@@ -40,6 +40,7 @@ parameters:
     - aomp-extras
     - hipBLAS-common
     - hipBLASLt
+    - roctracer
 - name: rocmTestDependencies
   type: object
   default:


### PR DESCRIPTION
Should fix recent build fails introduced by: https://github.com/ROCm/rocBLAS/commit/bb98ee0bf79152033bf8ccefc643d41d2fe7d710