### PR TITLE
External CI: decode test changes

### DIFF
--- a/.azuredevops/components/rocDecode.yml
+++ b/.azuredevops/components/rocDecode.yml
@@ -92,7 +92,10 @@ jobs:
   variables:
   - group: common
   - template: /.azuredevops/variables-global.yml
-  pool: $(JOB_TEST_POOL)
+  pool:
+    name: $(JOB_TEST_POOL)
+    demands:
+      - firstRenderDeviceAccess -equals "True"
   workspace:
     clean: all
   strategy:

--- a/.azuredevops/components/rocDecode.yml
+++ b/.azuredevops/components/rocDecode.yml
@@ -95,8 +95,7 @@ jobs:
   - template: /.azuredevops/variables-global.yml
   pool:
     name: $(JOB_TEST_POOL)
-    demands:
-      - firstRenderDeviceAccess -equals "True"
+    demands: firstRenderDeviceAccess
   workspace:
     clean: all
   strategy:
@@ -105,6 +104,18 @@ jobs:
         JOB_GPU_TARGET: gfx942
         JOB_TEST_POOL: ${{ variables.GFX942_TEST_POOL }}
   steps:
+  # Since mesa-amdgpu-multimedia-devel is not directly available from apt, register it
+  - task: Bash@3
+    displayName: 'Register ROCm packages'
+    inputs:
+      targetType: inline
+      script: |
+        sudo mkdir --parents --mode=0755 /etc/apt/keyrings
+        wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/${{ variables.KEYRING_VERSION }}/ubuntu jammy main" | sudo tee /etc/apt/sources.list.d/amdgpu.list
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${{ variables.KEYRING_VERSION }} jammy main" | sudo tee --append /etc/apt/sources.list.d/rocm.list
+        echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
+        sudo apt update
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
     parameters:
       aptPackages: ${{ parameters.aptPackages }}

--- a/.azuredevops/components/rocPyDecode.yml
+++ b/.azuredevops/components/rocPyDecode.yml
@@ -130,8 +130,7 @@ jobs:
   - template: /.azuredevops/variables-global.yml
   pool:
     name: $(JOB_TEST_POOL)
-    demands:
-      - firstRenderDeviceAccess -equals "True"
+    demands: firstRenderDeviceAccess
   workspace:
     clean: all
   strategy:
@@ -140,6 +139,17 @@ jobs:
         JOB_GPU_TARGET: gfx942
         JOB_TEST_POOL: ${{ variables.GFX942_TEST_POOL }}
   steps:
+  - task: Bash@3
+    displayName: Ensure pybind11-dev is not installed
+    inputs:
+      targetType: inline
+      script: |
+        if dpkg -l | grep -q pybind11-dev; then
+          echo "Removing pybind11-dev..."
+          sudo apt remove -y pybind11-dev
+        else
+          echo "pybind11-dev is not installed."
+        fi
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
     parameters:
       aptPackages: ${{ parameters.aptPackages }}
@@ -180,17 +190,6 @@ jobs:
         pip uninstall -y rocPyDecode
         find -name *.whl -exec pip install {} \;
       workingDirectory: $(Agent.BuildDirectory)
-  - task: Bash@3
-    displayName: Ensure pybind11-dev is not installed
-    inputs:
-      targetType: inline
-      script: |
-        if dpkg -l | grep -q pybind11-dev; then
-          echo "Removing pybind11-dev..."
-          sudo apt remove -y pybind11-dev
-        else
-          echo "pybind11-dev is not installed."
-        fi
   - task: Bash@3
     displayName: Setup search paths
     inputs:

--- a/.azuredevops/components/rocPyDecode.yml
+++ b/.azuredevops/components/rocPyDecode.yml
@@ -118,7 +118,10 @@ jobs:
   variables:
   - group: common
   - template: /.azuredevops/variables-global.yml
-  pool: $(JOB_TEST_POOL)
+  pool:
+    name: $(JOB_TEST_POOL)
+    demands:
+      - firstRenderDeviceAccess -equals "True"
   workspace:
     clean: all
   strategy:

--- a/.azuredevops/templates/steps/dependencies-other.yml
+++ b/.azuredevops/templates/steps/dependencies-other.yml
@@ -8,6 +8,12 @@ parameters:
   default: []
 
 steps:
+# firefox takes time to upgrade and is not needed for CI workloads, hold version
+- task: Bash@3
+  displayName: 'sudo apt-mark hold firefox'
+  inputs:
+    targetType: inline
+    script: sudo apt-mark hold firefox
 - task: Bash@3
   displayName: 'sudo apt-get update'
   inputs:


### PR DESCRIPTION
- Only target container with access to first device
- Install the amd va packages, not the generic dev packages
- Ensure pybind11-dev is uninstalled before the package manager install steps