### PR TITLE
Add Omniperf changelog to 6.2.1 release notes and fix RDC version in compat matrix

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -295,7 +295,7 @@ Click the component's updated version to go to a detailed list of its changes. C
             </tr>
             <tr>
                 <td><a href="https://rocm.docs.amd.com/projects/rdc/en/docs-6.2.1">ROCm Data Center Tool</a></td>
-                <td>1.0.0</td>
+                <td>0.3.0</td>
                 <td><a href="https://github.com/ROCm/rdc/releases/tag/rocm-6.2.1"><i
                             class="fab fa-github fa-lg"></i></a></td>
             </tr>

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -317,7 +317,7 @@ Click the component's updated version to go to a detailed list of its changes. C
                 <th rowspan="6"></th>
                 <th rowspan="6">Performance</th>
                 <td><a href="https://rocm.docs.amd.com/projects/omniperf/en/docs-6.2.1">Omniperf</a></td>
-                <td>2.0.1</td>
+                <td>2.0.1&nbsp;&Rightarrow;&nbsp;<a href="#omniperf-2-0-1">2.0.1</a></td>
                 <td><a href="https://github.com/ROCm/omniperf/releases/tag/rocm-6.2.1"><i
                             class="fab fa-github fa-lg"></i></a></td>
             </tr>
@@ -454,11 +454,32 @@ The following sections describe key changes to ROCm components.
 
 #### Changes
 
-* Added CUDA 12.5.1 support
-* Added cuDNN 9.2.1 support
-* Added LLVM 18.1.8 support
-* Added `hipBLAS` 64-bit APIs support
-* Added Support for math constants `math_constants.h`
+* Added CUDA 12.5.1 support.
+* Added cuDNN 9.2.1 support.
+* Added LLVM 18.1.8 support.
+* Added `hipBLAS` 64-bit APIs support.
+* Added Support for math constants `math_constants.h`.
+
+### **Omniperf** (2.0.1)
+
+#### Changes
+
+* Enabled rocprofv1 for MI300 hardware.
+* Added dependency checks on application launch.
+* Updated Omniperf packaging.
+* Rolled back Grafana version in Dockerfile for Angular plugin compatibility.
+* Added GPU model distinction for MI300 systems.
+* Refactored and updated documemtation.
+
+#### Resolved issues
+
+* Fixed an issue with analysis output.
+* Fixed issues with profiling multi-process and multi-GPU applications.
+
+#### Optimizations
+
+* Reduced running time of Omniperf when profiling.
+* Improved console logging.
 
 ### **Omnitrace** (1.11.2)
 

--- a/docs/compatibility/compatibility-matrix-historical-6.0.csv
+++ b/docs/compatibility/compatibility-matrix-historical-6.0.csv
@@ -82,7 +82,7 @@ ROCm Version,6.2.1,6.2.0, 6.1.2, 6.1.1, 6.1.0, 6.0.2, 6.0.0
       ,,,,,,,
       SYSTEM MGMT TOOLS,.. _tools-support-compatibility-matrix-past-60:,,,,,,
       :doc:`AMD SMI <amdsmi:index>`,24.6.3,24.6.2,24.5.1,24.5.1,24.4.1,23.4.2,23.4.2
-      :doc:`ROCm Data Center Tool <rdc:index>`,1.0.0,1.0.0,0.3.0,0.3.0,0.3.0,0.3.0,0.3.0
+      :doc:`ROCm Data Center Tool <rdc:index>`,0.3.0,0.3.0,0.3.0,0.3.0,0.3.0,0.3.0,0.3.0
       :doc:`rocminfo <rocminfo:index>`,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0,1.0.0
       :doc:`ROCm SMI <rocm_smi_lib:index>`,7.3.0,7.3.0,7.2.0,7.0.0,7.0.0,6.0.2,6.0.0
       :doc:`ROCm Validation Suite <rocmvalidationsuite:index>`,rocm-6.2.1,rocm-6.2.0,rocm-6.1.2,rocm-6.1.1,rocm-6.1.0,rocm-6.0.2,rocm-6.0.0

--- a/docs/compatibility/compatibility-matrix.rst
+++ b/docs/compatibility/compatibility-matrix.rst
@@ -103,7 +103,7 @@ You can also refer to the :ref:`past versions of ROCm compatibility matrix<past-
       ,,,
       SYSTEM MGMT TOOLS,.. _tools-support-compatibility-matrix:,,
       :doc:`AMD SMI <amdsmi:index>`,24.6.3,24.6.2,24.4.1
-      :doc:`ROCm Data Center Tool <rdc:index>`,1.0.0,1.0.0,0.3.0
+      :doc:`ROCm Data Center Tool <rdc:index>`,0.3.0,0.3.0,0.3.0
       :doc:`rocminfo <rocminfo:index>`,1.0.0,1.0.0,1.0.0
       :doc:`ROCm SMI <rocm_smi_lib:index>`,7.3.0,7.3.0,7.0.0
       :doc:`ROCm Validation Suite <rocmvalidationsuite:index>`,rocm-6.2.1,rocm-6.2.0,rocm-6.1.0


### PR DESCRIPTION
Add missed Omniperf changelog. See https://github.com/ROCm/rocprofiler-compute/pull/461.

Also fix RDC version numbers in release notes and compatibility matrix.