### PR TITLE
External CI: add aomp as rocprofiler-systems dependency

### DIFF
--- a/.azuredevops/components/rocprofiler-systems.yml
+++ b/.azuredevops/components/rocprofiler-systems.yml
@@ -40,6 +40,7 @@ parameters:
 - name: rocmDependencies
   type: object
   default:
+    - aomp
     - clr
     - llvm-project
     - rccl


### PR DESCRIPTION
To fix build failure: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=13364&view=results