### PR TITLE
External CI: disable rdmatest and rocrtstFunc.Memory_Max_Mem

### DIFF
--- a/.azuredevops/components/ROCR-Runtime.yml
+++ b/.azuredevops/components/ROCR-Runtime.yml
@@ -122,41 +122,6 @@ jobs:
       testParameters: '-p core --gtest_output=xml:./test_output.xml --gtest_color=yes'
       testDir: $(Build.SourcesDirectory)/libhsakmt/tests/kfdtest/scripts
   - task: Bash@3
-    displayName: Build rdmatest app
-    continueOnError: true
-    inputs:
-      targetType: 'inline'
-      workingDirectory: $(Build.SourcesDirectory)/libhsakmt/tests/rdma/simple/app
-      script: |
-        cmake -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm -DLIBHSAKMT_PATH=$(Agent.BuildDirectory)/rocm -DDRM_AMDGPU_INCLUDE_DIRS=$(Agent.BuildDirectory)/rocm/include .
-        cmake --build .
-  - task: Bash@3
-    displayName: Build rdmatest driver
-    continueOnError: true
-    inputs:
-      targetType: 'inline'
-      workingDirectory: $(Build.SourcesDirectory)/libhsakmt/tests/rdma/simple/drv
-      script: |
-        sed -i 's/HSAKMT_PAGE_SHIFT/PAGE_SHIFT/g' amdp2ptest.c
-        sed -i 's/"MIT"/"GPL"/' amdp2ptest.c
-        RDMA_HEADER_DIR=/usr/src/amdgpu-*/include make all
-  - task: Bash@3
-    displayName: Install rdmatest driver
-    continueOnError: true
-    inputs:
-      targetType: 'inline'
-      workingDirectory: $(Build.SourcesDirectory)/libhsakmt/tests/rdma/simple/drv
-      script: |
-        sudo rmmod amdp2ptest.ko
-        sudo insmod amdp2ptest.ko
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
-    parameters:
-      componentName: rdmatest
-      testExecutable: yes | ./rdma_test
-      testParameters: ''
-      testDir: $(Build.SourcesDirectory)/libhsakmt/tests/rdma/simple/app
-      testPublishResults: false
-  - task: Bash@3
     displayName: Build rocrtst
     continueOnError: true
     inputs:
@@ -179,5 +144,5 @@ jobs:
     parameters:
       componentName: rocrtst
       testExecutable: ./rocrtst64
-      testParameters: '--gtest_filter="-rocrtstNeg.Memory_Negative_Tests" --gtest_output=xml:./test_output.xml --gtest_color=yes'
+      testParameters: '--gtest_filter="-rocrtstNeg.Memory_Negative_Tests:rocrtstFunc.Memory_Max_Mem" --gtest_output=xml:./test_output.xml --gtest_color=yes'
       testDir: $(Build.SourcesDirectory)/rocrtst/suites/test_common/build/$(JOB_GPU_TARGET)


### PR DESCRIPTION
Disable rdmatest and rocrtstFunc.Memory_Max_Mem as they don't work in Docker containers