### PR TITLE
External CI: increase Tensile test timeout to 90 mins

### DIFF
--- a/.azuredevops/components/Tensile.yml
+++ b/.azuredevops/components/Tensile.yml
@@ -78,6 +78,7 @@ jobs:
       targetPath: $(Build.ArtifactStagingDirectory)
 
 - job: Tensile_testing
+  timeoutInMinutes: 90
   dependsOn: Tensile
   condition: and(succeeded(), eq(variables.ENABLE_GFX942_TESTS, 'true'), not(containsValue(split(variables.DISABLED_GFX942_TESTS, ','), variables['Build.DefinitionName'])))
   variables:


### PR DESCRIPTION
Tensile's tox test takes 1 hour ± a few minutes, so increase the time limit to 90 mins.