### PR TITLE
External CI: AOMP symlink fix and manifest additions

### DIFF
--- a/.azuredevops/components/aomp.yml
+++ b/.azuredevops/components/aomp.yml
@@ -200,7 +200,7 @@ jobs:
       AOMP: $(Build.BinariesDirectory)
       AOMP_INSTALL_DIR: $(Build.BinariesDirectory)
       INSTALL_OPENMP: $(Build.BinariesDirectory)
-  - script: ln -s $(Build.BinariesDirectory)/include/omp.h $(Build.SourcesDirectory)/llvm-project/llvm/include/omp.h
+  - script: ln -s $(Build.BinariesDirectory)/lib/llvm/include/omp.h $(Build.SourcesDirectory)/llvm-project/llvm/include/omp.h
     displayName: Link omp header
   - task: Bash@3
     displayName: Build offload

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -107,6 +107,7 @@ jobs:
     displayName: System disk space after ROCm
   - script: du -sh $(Agent.BuildDirectory)/rocm
     displayName: Uncompressed ROCm size
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
   - task: ArchiveFiles@2
     displayName: Compress rocm-nightly
     inputs:

--- a/.azuredevops/templates/steps/manifest.yml
+++ b/.azuredevops/templates/steps/manifest.yml
@@ -1,6 +1,7 @@
 steps:
 - task: Bash@3
   displayName: Set up current_repo values
+  condition: always()
   continueOnError: true
   inputs:
     targetType: inline
@@ -28,6 +29,7 @@ steps:
       echo "##vso[task.setvariable variable=current_repo.version;]$(jq .$REPO_TYPE.version resources.repositories | tr -d '"')"
 - task: Bash@3
   displayName: Create manifest.json
+  condition: always()
   continueOnError: true
   inputs:
     targetType: inline
@@ -76,6 +78,7 @@ steps:
       cat $(Build.ArtifactStagingDirectory)/manifest_$(Build.DefinitionName).json
 - task: Bash@3
   displayName: Create manifest.html
+  condition: always()
   continueOnError: true
   inputs:
     targetType: inline
@@ -117,6 +120,7 @@ steps:
       cat $(Build.ArtifactStagingDirectory)/manifest_$(Build.DefinitionName).html
 - task: PublishHtmlReport@1
   displayName: Publish manifest.html
+  condition: always()
   continueOnError: true
   inputs:
     tabName: Manifest


### PR DESCRIPTION
- Corrects location of omp.h header file for symlink creation
  - Refer: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=15814&view=logs&j=96f6ff47-56da-531a-589c-8e03d8a52c15&t=9dbec5b4-3462-5a97-7d43-c8ac1937474e&l=18
- Adds manifest creation to the nightly job
- Adds always conditions to manifest steps to create them even for failed builds

AOMP build log: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=15826&view=results