### PR TITLE
remove programming guide from TOC (#4116)

### DIFF
--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -32,8 +32,6 @@ subtrees:
 
 - caption: How to
   entries:
-  - file: how-to/programming_guide.rst
-    title: Programming guide
   - file: how-to/rocm-for-ai/index.rst
     title: Use ROCm for AI
     subtrees:


### PR DESCRIPTION
(cherry picked from commit 1a4d54a4f12b83f75b4c78e5afa0c8cce62eabaa)