### PR TITLE
Fix build instruction errors:

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The following example shows how to use the repo tool to download the ROCm source
 ```bash
 mkdir -p ~/ROCm/
 cd ~/ROCm/
-export ROCM_VERSION=6.3.0
+export ROCM_VERSION=6.3.1
 ~/bin/repo init -u http://github.com/ROCm/ROCm.git -b roc-6.3.x -m tools/rocm-build/rocm-${ROCM_VERSION}.xml
 ~/bin/repo sync
 ```
@@ -78,7 +78,7 @@ The Build time will reduce significantly if we limit the GPU Architecture/s agai
 
 mkdir -p ~/WORKSPACE/      # Or any folder name other than WORKSPACE
 cd ~/WORKSPACE/
-export ROCM_VERSION=6.3.0
+export ROCM_VERSION=6.3.1
 ~/bin/repo init -u http://github.com/ROCm/ROCm.git -b roc-6.3.x -m tools/rocm-build/rocm-${ROCM_VERSION}.xml
 ~/bin/repo sync
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ The following example shows how to use the repo tool to download the ROCm source
 ```bash
 mkdir -p ~/ROCm/
 cd ~/ROCm/
-~/bin/repo init -u http://github.com/ROCm/ROCm.git -b roc-6.3.x
+export ROCM_VERSION=6.3.0
+~/bin/repo init -u http://github.com/ROCm/ROCm.git -b roc-6.3.x -m tools/rocm-build/rocm-${ROCM_VERSION}.xml
 ~/bin/repo sync
 ```
 
 **Note:** Using this sample code will cause the repo tool to download the open source code associated with the specified ROCm release. Ensure that you have ssh-keys configured on your machine for your GitHub ID prior to the download as explained at [Connecting to GitHub with SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh).
+
 
 ## Building the ROCm source code
 
@@ -76,7 +78,7 @@ The Build time will reduce significantly if we limit the GPU Architecture/s agai
 
 mkdir -p ~/WORKSPACE/      # Or any folder name other than WORKSPACE
 cd ~/WORKSPACE/
-export ROCM_VERSION=6.3.1
+export ROCM_VERSION=6.3.0
 ~/bin/repo init -u http://github.com/ROCm/ROCm.git -b roc-6.3.x -m tools/rocm-build/rocm-${ROCM_VERSION}.xml
 ~/bin/repo sync
 


### PR DESCRIPTION
These were encountered while debugging
https://github.com/ROCm/ROCm/issues/4190

- There is no manifest (-m) for ROCm 6.3.1 in the tools/rocm-build folder 
  - Changed the rocm version to 6.3.0 to avoid immediate build failure. This would be better remedied by adding a ROCm 6.3.1 XML in the tools/rocm-build folder

- The manifest is not specified in the first instance of "Downloading the ROCm source code", but it is in "Build ROCm from source". 
  - Without the correct manifest, subsequent build instructions will fail as the ROCm/ROCm directory doesn't get pulled by the default manifest. It's unclear why these two otherwise identical commands are duplicated and have this discrepancy