### PR TITLE
External CI: increase MIOpen test timeout to 180 min

### DIFF
--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -120,7 +120,7 @@ jobs:
       gpuTarget: $(JOB_GPU_TARGET)
 
 - job: MIOpen_testing
-  timeoutInMinutes: 90
+  timeoutInMinutes: 180
   dependsOn: MIOpen
   condition: and(succeeded(), eq(variables.ENABLE_GFX942_TESTS, 'true'), not(containsValue(split(variables.DISABLED_GFX942_TESTS, ','), variables['Build.DefinitionName'])))
   variables:


### PR DESCRIPTION
Fix for MIOpen tests timing out due to an increase in the # of tests. 

Successful build & test logs (CK build warning is a separate issue):
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=17744&view=results