### PR TITLE
External CI: add libdrm-dev package to rocm_smi_lib

### DIFF
--- a/.azuredevops/components/rocm_smi_lib.yml
+++ b/.azuredevops/components/rocm_smi_lib.yml
@@ -5,6 +5,10 @@ parameters:
 - name: checkoutRef
   type: string
   default: ''
+- name: aptPackages
+  type: object
+  default:
+    - libdrm-dev
 
 jobs:
 - job: rocm_smi_lib
@@ -16,6 +20,9 @@ jobs:
   workspace:
     clean: all
   steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
     parameters:


### PR DESCRIPTION
Adds `libdrm-dev` package to fix a build error introduced by https://github.com/ROCm/rocm_smi_lib/commit/6f51cd651e4116b04c2df6a2afe8859558bdba66

Successful build log:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=17777&view=results