### PR TITLE
External CI: add rocprofiler-sdk to RDC

### DIFF
--- a/.azuredevops/components/rdc.yml
+++ b/.azuredevops/components/rdc.yml
@@ -37,6 +37,7 @@ parameters:
     - ROCmValidationSuite
     - rocprofiler
     - rocprofiler-register
+    - rocprofiler-sdk
     - ROCR-Runtime
 - name: rocmTestDependencies
   type: object


### PR DESCRIPTION
Fix for RDC build failure introduced in https://github.com/ROCm/rdc/commit/7c91a07a4318c03197da27021a711585d00fb77e

Successful build:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=17781&view=results