### PR TITLE
External CI: small fixes for RCCL, RPP, MIOpen, CK

### DIFF
--- a/.azuredevops/components/composable_kernel.yml
+++ b/.azuredevops/components/composable_kernel.yml
@@ -101,6 +101,7 @@ jobs:
       gpuTarget: $(JOB_GPU_TARGET)
 
 - job: composable_kernel_testing
+  timeoutInMinutes: 90
   dependsOn: composable_kernel
   condition: and(succeeded(), eq(variables.ENABLE_GFX942_TESTS, 'true'), not(containsValue(split(variables.DISABLED_GFX942_TESTS, ','), variables['Build.DefinitionName'])))
   variables:

--- a/.azuredevops/components/rccl.yml
+++ b/.azuredevops/components/rccl.yml
@@ -8,15 +8,16 @@ parameters:
 - name: aptPackages
   type: object
   default:
-    - python3-pip
     - cmake
-    - libboost-program-options-dev
-    - googletest
-    - libfftw3-dev
     - git
-    - ninja-build
-    - libstdc++-12-dev
+    - googletest
+    - libboost-program-options-dev
+    - libdrm-dev
+    - libfftw3-dev
     - libnuma-dev
+    - libstdc++-12-dev
+    - ninja-build
+    - python3-pip
 - name: rocmDependencies
   type: object
   default:

--- a/.azuredevops/components/rpp.yml
+++ b/.azuredevops/components/rpp.yml
@@ -8,13 +8,13 @@ parameters:
 - name: aptPackages
   type: object
   default:
+    - clang
     - cmake
+    - imagemagick
     - libopencv-dev
     - libsndfile1-dev
     - libstdc++-12-dev
-    - imagemagick
     - ninja-build
-    - clang
 - name: pipModules
   type: object
   default:
@@ -83,7 +83,7 @@ jobs:
         -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
         -DHALF_INCLUDE_DIRS=$(Agent.BuildDirectory)/rocm/include
         -DCMAKE_BUILD_TYPE=Release
-        -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
+        -DGPU_TARGETS=$(JOB_GPU_TARGET)
         -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
     parameters:
@@ -156,7 +156,7 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        git clone https://github.com/NIFTI-Imaging/nifti_clib.git
+        git clone -b v3.0.1 https://github.com/NIFTI-Imaging/nifti_clib.git
         cd nifti_clib
         mkdir build
         cd build

--- a/.azuredevops/templates/steps/miopen-get-ck-build.yml
+++ b/.azuredevops/templates/steps/miopen-get-ck-build.yml
@@ -36,7 +36,7 @@ steps:
 
       if [ -z "$CK_BUILD_ID" ]; then
         echo "Did not find specific CK build ID"
-        LATEST_BUILD_URL="$AZ_API/build/builds?definitions=$(COMPOSABLE_KERNEL_PIPELINE_ID)&status=completed&result=succeeded&\$top=1&api-version=7.1"
+        LATEST_BUILD_URL="$AZ_API/build/builds?definitions=$(COMPOSABLE_KERNEL_PIPELINE_ID)&statusFilter=completed&resultFilter=succeeded&\$top=1&api-version=7.1"
         CK_BUILD_ID=$(curl -s $LATEST_BUILD_URL | jq '.value[0].id')
         echo "Found latest CK build ID: $CK_BUILD_ID"
         EXIT_CODE=1


### PR DESCRIPTION
RCCL:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=17896&view=results
- Added `libdrm-dev` to packages
- Sorted apt packages

RPP:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=17900&view=results
- Freeze NIFTI to v3.0.1
- Change `AMDGPU_TARGETS` flag to `GPU_TARGETS` to resolve deprecation warning
- Sorted apt packages

MIOpen:
- Fixed incorrect Azure API parameters to prevent downloading failed CK builds

composable_kernel:
- Increased test timeout to 90 mins