### PR TITLE
[docs/6.3.1] remove `windows` from pytorch compat header (#4219)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,7 @@ all_article_info_author = ""
 # pages with specific settings
 article_pages = [
     {"file": "about/release-notes", "os": ["linux", "windows"], "date": "2024-12-20"},
+    {"file": "compatibility/pytorch-compatibility", "os": ["linux"]},
     {"file": "how-to/deep-learning-rocm", "os": ["linux"]},
     {"file": "how-to/rocm-for-ai/index", "os": ["linux"]},
     {"file": "how-to/rocm-for-ai/install", "os": ["linux"]},


### PR DESCRIPTION
(cherry picked from commit eafa2de533c054240bcb608e367654d424e408b5)