### PR TITLE
External CI: add missing rocAL functionalities

### DIFF
--- a/.azuredevops/components/rocAL.yml
+++ b/.azuredevops/components/rocAL.yml
@@ -21,6 +21,8 @@ parameters:
     - libavcodec-dev
     - libavformat-dev
     - libavutil-dev
+    - libdlpack-dev
+    - libsndfile1-dev
     - libswscale-dev
     - libturbojpeg-dev
     - libjpeg-turbo-official=3.0.2-20240124
@@ -149,6 +151,7 @@ jobs:
         -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;/opt/libjpeg-turbo
         -DCMAKE_INSTALL_PREFIX_PYTHON=$Python3_STDARCH
         -DCMAKE_BUILD_TYPE=Release
+        -DGPU_TARGETS=$(JOB_GPU_TARGET)
         -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
     parameters:


### PR DESCRIPTION
Adds `libdlpack-dev` and `libsndfile1-dev` packages to resolve https://github.com/ROCm/rocAL/issues/258.

Also adds `GPU_TARGETS` build flag.

Build logs: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=18031&view=logs&j=82dddf77-1810-596a-155f-4c5d5ecc99c3&t=0510f471-8adb-52df-cfd3-7d6ab5c4c1b5