### PR TITLE
HPC application list updated 6.3.1 (#4066)

### DIFF
--- a/docs/how-to/rocm-for-hpc/index.rst
+++ b/docs/how-to/rocm-for-hpc/index.rst
@@ -115,6 +115,12 @@ Ubuntu versions.
           for non-destructive testing or for ocean acoustics.
 
       * - Molecular dynamics
+        - `Amber <https://github.com/amd/InfinityHub-CI/tree/main/amber>`_
+        - Amber is a suite of biomolecular simulation programs. It is a set of molecular mechanical force fields for 
+          simulating biomolecules. Amber is also a package of molecular simulation 
+          programs which includes source code and demos.
+
+      * - 
         - `GROMACS with HIP (AMD implementation) <https://github.com/amd/InfinityHub-CI/tree/main/gromacs>`_
         - GROMACS is a versatile package to perform molecular dynamics, i.e.
           simulate the Newtonian equations of motion for systems with hundreds
@@ -129,6 +135,13 @@ Ubuntu versions.
           Parallel Simulator.
 
       * - Computational fluid dynamics
+        - `Ansys Fluent <https://github.com/amd/InfinityHub-CI/tree/main/ansys-fluent>`_
+        - Ansys Fluent is an advanced computational fluid dynamics (CFD) tool for 
+          simulating and analyzing fluid flow, heat transfer, and related phenomena in complex systems. 
+          It offers a range of powerful features for detailed and accurate modeling of various physical 
+          processes, including turbulence, chemical reactions, and multiphase flows.
+
+      * -
         - `NEKO <https://github.com/amd/InfinityHub-CI/tree/main/neko>`_
         - Neko is a portable framework for high-order spectral element flow simulations.
           Written in modern Fortran, Neko adopts an object-oriented approach, allowing
@@ -140,6 +153,26 @@ Ubuntu versions.
         - `nekRS <https://github.com/amd/InfinityHub-CI/tree/main/nekrs>`_
         - nekRS is an open-source Navier Stokes solver based on the spectral element
           method targeting classical processors and accelerators like GPUs. 
+
+      * -
+        - `OpenFOAM <https://github.com/amd/InfinityHub-CI/tree/main/openfoam>`_
+        - OpenFOAM is a free, open-source computational fluid dynamics (CFD) 
+          tool developed primarily by OpenCFD Ltd. It has a large user 
+          base across most areas of engineering and science, from both commercial and 
+          academic organizations. OpenFOAM has extensive features to solve 
+          anything from complex fluid flows involving chemical reactions, turbulence, and 
+          heat transfer, to acoustics, solid mechanics, and electromagnetics.
+
+      * -
+        - `PeleC <https://github.com/amd/InfinityHub-CI/tree/main/pelec>`_
+        - PeleC is an adaptive mesh refinement(AMR) solver for compressible reacting flows.
+
+      * -
+        - `Simcenter Star-CCM+ <https://github.com/amd/InfinityHub-CI/tree/main/siemens-star-ccm>`_
+        - Simcenter Star-CCM+ is a comprehensive computational fluid dynamics (CFD) and multiphysics 
+          simulation tool developed by Siemens Digital Industries Software. It is designed to 
+          help engineers and researchers analyze and optimize the performance of products and 
+          systems across various industries.
 
       * - Computational chemistry
         - `QUDA <https://github.com/amd/InfinityHub-CI/tree/main/quda>`_
@@ -170,12 +203,30 @@ Ubuntu versions.
           developing atmosphere, ocean, and other earth-system simulation components
           for use in climate, regional climate, and weather studies.
 
+      * - Energy, Oil, and Gas
+        - `DevitoPRO <https://github.com/amd/InfinityHub-CI/tree/main/devitopro>`_
+        - DevitoPRO is an advanced extension of the open-source Devito platform with added 
+          features tailored for high-demand production workflows. It supports
+          high-performance computing (HPC) needs, especially in seismic imaging and inversion. 
+          It is used to perform optimized finite difference (FD) computations 
+          from high-level symbolic problem definitions. DevitoPro performs automated 
+          code generation and Just-In-time (JIT) compilation based on symbolic equations 
+          defined in SymPy to create and execute highly optimized Finite Difference stencil 
+          kernels on multiple computer platforms.
+
+      * - 
+        - `ECHELON <https://github.com/amd/InfinityHub-CI/tree/main/srt-echelon>`_
+        - ECHELON by Stone Ridge Technology is a reservoir simulation tool. With 
+          fast processing, it retains precise accuracy and preserves legacy simulator results. 
+          Faster reservoir simulation enables reservoir engineers to produce many realizations, 
+          address larger models, and use advanced physics. It opens new workflows based on 
+          ensemble methodologies for history matching and forecasting that yield 
+          increased accuracy and more predictive results.
+
       * - Benchmark
         - `rocHPL <https://github.com/amd/InfinityHub-CI/tree/main/rochpl>`_
         - HPL, or High-Performance Linpack, is a benchmark which solves a uniformly 
-          random system of linear equations and reports floating-point execution rate. 
-          This documentation supports the implementation of the HPL benchmark on 
-          top of AMD's ROCm platform.
+          random system of linear equations and reports floating-point execution rate.
 
       * -
         - `rocHPL-MxP <https://github.com/amd/InfinityHub-CI/tree/main/hpl-mxp>`_
@@ -215,6 +266,14 @@ Ubuntu versions.
           unstructured grids containing various element types. It is also designed to target a
           range of hardware platforms via use of an in-built domain specific language derived
           from the Mako templating engine.
+
+      * -
+        - `PETSc <https://github.com/amd/InfinityHub-CI/tree/main/petsc>`_
+        - Portable, Extensible Toolkit for Scientific Computation (PETSc) is a suite of data structures 
+          and routines for the scalable (parallel) solution of scientific applications modeled by partial 
+          differential equations. It supports MPI, GPUs through CUDA, HIP, and OpenCL, 
+          as well as hybrid MPI-GPU parallelism. It also supports the NEC-SX Tsubasa Vector Engine. 
+          PETSc also includes the Toolkit for Advanced Optimization (TAO) library.
 
       * -
         - `RAJA <https://github.com/amd/InfinityHub-CI/tree/main/raja>`_


### PR DESCRIPTION
Added the following applications to the Using ROCm for HPC page application list:
Ansys Fluent
Amber
DevitoPRO
OpenFOAM (OpenFOAM with PETSc Solver)
PeleC
PETSc
Simcenter Star-CCM+ (Siemens StarCCM+)
Echelon (Stone Ridge Technology ECHELON)

Cherry-picked from https://github.com/ROCm/ROCm/pull/4066