### PR TITLE
External CI: add libdrm-dev to RVS, rocWMMA

### DIFF
--- a/.azuredevops/components/ROCmValidationSuite.yml
+++ b/.azuredevops/components/ROCmValidationSuite.yml
@@ -10,6 +10,7 @@ parameters:
   default:
     - cmake
     - ninja-build
+    - libdrm-dev
     - libyaml-cpp-dev
     - libpci-dev
     - libpci3

--- a/.azuredevops/components/rocWMMA.yml
+++ b/.azuredevops/components/rocWMMA.yml
@@ -12,6 +12,7 @@ parameters:
     - cmake
     - ninja-build
     - libboost-program-options-dev
+    - libdrm-dev
     - libgtest-dev
     - googletest
     - libfftw3-dev
@@ -82,7 +83,7 @@ jobs:
         -DCMAKE_BUILD_TYPE=Release
         -DROCWMMA_BUILD_TESTS=ON
         -DROCWMMA_BUILD_SAMPLES=OFF
-        -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
+        -DGPU_TARGETS=$(JOB_GPU_TARGET)
         -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
         -GNinja
 # gfx1030 not supported in documentation


### PR DESCRIPTION
Fixes build failures for RVS and rocWMMA due to missing `libdrm`.

Also changes `AMDGPU_TARGETS` to `GPU_TARGETS` for rocWMMA.

rocWMMA: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=18332&view=results
RVS: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=18333&view=results