### PR TITLE
Remove code object version at build in hipBLASLt

### DIFF
--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -137,7 +137,6 @@ jobs:
         -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
         -DTensile_LOGIC=
         -DTensile_CPU_THREADS=
-        -DTensile_CODE_OBJECT_VERSION=default
         -DTensile_LIBRARY_FORMAT=msgpack
         -DCMAKE_PREFIX_PATH="$(Agent.BuildDirectory)/rocm"
         -DBUILD_CLIENTS_TESTS=ON


### PR DESCRIPTION
hipBLASLt uses internal defaults for the code object version, and upcoming updates improve the robustness of this option when unspecified. This PR simply removes the parameter from the cmake options and leaves it up to hipBLASLt/TensileLite to determine the best default.