### PR TITLE
Docs: resolve warnings from sphinx build output

### DIFF
--- a/docs/compatibility/compatibility-matrix.rst
+++ b/docs/compatibility/compatibility-matrix.rst
@@ -158,7 +158,7 @@ Operating systems and kernel versions
 
 Use this lookup table to confirm which operating system and kernel versions are supported with ROCm.
 
-.. csv-table:: 
+.. csv-table::
    :header: "OS", "Version", "Kernel"
    :widths: 40, 20, 40
    :stub-columns: 1
@@ -169,11 +169,11 @@ Use this lookup table to confirm which operating system and kernel versions are 
    `Ubuntu <https://ubuntu.com/about/release-cycle#ubuntu-kernel-release-cycle>`_, 22.04.5, "5.15 GA, 6.8 HWE"
    , 22.04.4, "5.15 GA, 6.5 HWE"
    ,,
-   `Red Hat Enterprise Linux (RHEL) <https://access.redhat.com/articles/3078#RHEL9>`_, 9.5, 5.14.0
+   `Red Hat Enterprise Linux (RHEL 9) <https://access.redhat.com/articles/3078#RHEL9>`_, 9.5, 5.14.0
    ,9.4, 5.14.0
    ,9.3, 5.14.0
    ,,
-   `Red Hat Enterprise Linux (RHEL) <https://access.redhat.com/articles/3078#RHEL8>`_, 8.10, 4.18.0
+   `Red Hat Enterprise Linux (RHEL 8) <https://access.redhat.com/articles/3078#RHEL8>`_, 8.10, 4.18.0
    ,8.9, 4.18.0
    ,,
    `SUSE Linux Enterprise Server (SLES) <https://www.suse.com/support/kb/doc/?id=000019587#SLE15SP4>`_, 15 SP6, 6.4.0
@@ -185,9 +185,9 @@ Use this lookup table to confirm which operating system and kernel versions are 
    `Debian <https://www.debian.org/download>`_,12, 6.1
 
 ..
-   Footnotes and ref anchors in below historical tables should be appended with "-past-60", to differentiate from the 
+   Footnotes and ref anchors in below historical tables should be appended with "-past-60", to differentiate from the
    footnote references in the above, latest, compatibility matrix.  It also allows to easily find & replace.
-   An easy way to work is to download the historical.CSV file, and update open it in excel. Then when content is ready, 
+   An easy way to work is to download the historical.CSV file, and update open it in excel. Then when content is ready,
    delete the columns you don't need, to build the current compatibility matrix to use in above table.  Find & replace all
    instances of "-past-60" to make it ready for above table.
 

--- a/docs/compatibility/ml-compatibility/jax-compatibility.rst
+++ b/docs/compatibility/ml-compatibility/jax-compatibility.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. meta::
    :description: JAX compatibility
    :keywords: GPU, JAX compatibility
@@ -22,14 +24,14 @@ support:
 
   - Offers AMD-validated and community :ref:`Docker images <jax-docker-compat>` with ROCm and JAX pre-installed.
 
-  - ROCm JAX repository: `<https://github.com/ROCm/jax>`__
+  - ROCm JAX repository: `ROCm/jax <https://github.com/ROCm/jax>`_
 
   - See the :doc:`ROCm JAX installation guide <rocm-install-on-linux:install/3rd-party/jax-install>`
     to get started.
 
 - Official JAX release:
 
-  - Official JAX repository: `<https://github.com/jax-ml/jax>`__
+  - Official JAX repository: `jax-ml/jax <https://github.com/jax-ml/jax>`_
 
   - See the `AMD GPU (Linux) installation section
     <https://jax.readthedocs.io/en/latest/installation.html#amd-gpu-linux>`_ in the JAX
@@ -51,8 +53,8 @@ Docker image compatibility
 
    <i class="fab fa-docker"></i>
 
-AMD validates and publishes ready-made `JAX <https://hub.docker.com/r/rocm/jax/>`_
-images with ROCm backends on Docker Hub. The following Docker image tags and
+AMD validates and publishes ready-made `ROCm JAX Docker images <https://hub.docker.com/r/rocm/jax>`_
+with ROCm backends on Docker Hub. The following Docker image tags and
 associated inventories are validated for
 `ROCm 6.3.1 <https://repo.radeon.com/rocm/apt/6.3.1/>`_. Click the |docker-icon|
 icon to view the image on Docker Hub.
@@ -79,8 +81,8 @@ icon to view the image on Docker Hub.
       - Ubuntu 22.04
       - `3.10.14 <https://www.python.org/downloads/release/python-31014/>`_
 
-AMD publishes community `JAX <https://hub.docker.com/r/rocm/jax-community>`_
-images with ROCm backends on Docker Hub. The following Docker image tags and
+AMD publishes `Community ROCm JAX Docker images <https://hub.docker.com/r/rocm/jax-community>`_
+with ROCm backends on Docker Hub. The following Docker image tags and
 associated inventories are tested for `ROCm 6.2.4 <https://repo.radeon.com/rocm/apt/6.2.4/>`_.
 
 .. list-table:: JAX community Docker image components
@@ -148,7 +150,7 @@ performance, and feature set available to developers.
       - 3.3.0
       - Provides a C++ template library for parallel algorithms for reduction,
         scan, sort and select.
-      - Reduction functions (``jax.numpy.sum``, ``jax.numpy.mean``, 
+      - Reduction functions (``jax.numpy.sum``, ``jax.numpy.mean``,
         ``jax.numpy.prod``, ``jax.numpy.max`` and ``jax.numpy.min``), prefix sum
         (``jax.numpy.cumsum``, ``jax.numpy.cumprod``) and sorting
         (``jax.numpy.sort``, ``jax.numpy.argsort``).
@@ -166,7 +168,7 @@ performance, and feature set available to developers.
       - Provides GPU-accelerated solvers for linear systems, eigenvalues, and
         singular value decompositions (SVD).
       - Solving linear systems (``jax.numpy.linalg.solve``), matrix
-        factorizations, SVD (``jax.numpy.linalg.svd``) and eigenvalue problems 
+        factorizations, SVD (``jax.numpy.linalg.svd``) and eigenvalue problems
         (``jax.numpy.linalg.eig``).
     * - `hipSPARSE <https://github.com/ROCm/hipSPARSE>`_
       - 3.1.2
@@ -259,7 +261,7 @@ ROCm and JAX versions.
       - Provides utilities for working with and managing data types in JAX
         arrays and computations.
       - 0.1.66
-      - 5.0.0 
+      - 5.0.0
     * - ``jax.image``
       - Contains image manipulation functions like resize, scale and translation.
       - 0.1.57
@@ -317,7 +319,7 @@ ROCm and JAX versions.
       - 5.3.0
     * - ``jax_triton``
       - Library that integrates the Triton deep learning compiler with JAX.
-      - jax_triton 0.2.0 
+      - jax_triton 0.2.0
       - 6.2.4
 
 jax.scipy module

--- a/docs/compatibility/ml-compatibility/pytorch-compatibility.rst
+++ b/docs/compatibility/ml-compatibility/pytorch-compatibility.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. meta::
     :description: PyTorch compatibility
     :keywords: GPU, PyTorch compatibility
@@ -23,7 +25,7 @@ release cycles for PyTorch on ROCm:
   - Offers :ref:`Docker images <pytorch-docker-compat>` with ROCm and PyTorch
     pre-installed.
 
-  - ROCm PyTorch repository: `<https://github.com/ROCm/pytorch>`__
+  - ROCm PyTorch repository: `<https://github.com/ROCm/pytorch>`_
 
   - See the :doc:`ROCm PyTorch installation guide <rocm-install-on-linux:install/3rd-party/pytorch-install>` to get started.
 
@@ -31,7 +33,7 @@ release cycles for PyTorch on ROCm:
 
   - Provides the latest stable version of PyTorch but doesn't immediately support the latest ROCm version.
 
-  - Official PyTorch repository: `<https://github.com/pytorch/pytorch>`__
+  - Official PyTorch repository: `<https://github.com/pytorch/pytorch>`_
 
   - See the `Nightly and latest stable version installation guide <https://pytorch.org/get-started/locally/>`_
     or `Previous versions <https://pytorch.org/get-started/previous-versions/>`_ to get started.
@@ -52,8 +54,8 @@ Docker image compatibility
 
    <i class="fab fa-docker"></i>
 
-AMD validates and publishes ready-made `PyTorch <https://hub.docker.com/r/rocm/pytorch>`_
-images with ROCm backends on Docker Hub. The following Docker image tags and
+AMD validates and publishes ready-made `PyTorch images <https://hub.docker.com/r/rocm/pytorch>`_
+with ROCm backends on Docker Hub. The following Docker image tags and
 associated inventories are validated for `ROCm 6.3.0 <https://repo.radeon.com/rocm/apt/6.3/>`_.
 Click the |docker-icon| icon to view the image on Docker Hub.
 
@@ -82,7 +84,7 @@ Click the |docker-icon| icon to view the image on Docker Hub.
       - `3.12 <https://www.python.org/downloads/release/python-3128/>`_
       - `1.4.0 <https://github.com/ROCm/apex/tree/release/1.4.0>`_
       - `0.19.0 <https://github.com/pytorch/vision/tree/v0.19.0>`_
-      - `2.13.0 <https://github.com/tensorflow/tensorboard/tree/2.13>`_
+      - `2.13.0 <https://github.com/tensorflow/tensorboard/tree/2.13.0>`_
       - `master <https://bitbucket.org/icl/magma/src/master/>`_
       - `1.10.0 <https://github.com/openucx/ucx/tree/v1.10.0>`_
       - `4.0.7 <https://github.com/open-mpi/ompi/tree/v4.0.7>`_
@@ -97,7 +99,7 @@ Click the |docker-icon| icon to view the image on Docker Hub.
       - `3.10 <https://www.python.org/downloads/release/python-31016/>`_
       - `1.4.0 <https://github.com/ROCm/apex/tree/release/1.4.0>`_
       - `0.19.0 <https://github.com/pytorch/vision/tree/v0.19.0>`_
-      - `2.13.0 <https://github.com/tensorflow/tensorboard/tree/2.13>`_
+      - `2.13.0 <https://github.com/tensorflow/tensorboard/tree/2.13.0>`_
       - `master <https://bitbucket.org/icl/magma/src/master/>`_
       - `1.10.0 <https://github.com/openucx/ucx/tree/v1.10.0>`_
       - `4.0.7 <https://github.com/open-mpi/ompi/tree/v4.0.7>`_
@@ -109,10 +111,10 @@ Click the |docker-icon| icon to view the image on Docker Hub.
 
       - `2.4.0 <https://github.com/ROCm/pytorch/tree/release/2.4>`_
       - 22.04
-      - `3.9 <https://www.python.org/downloads/release/python-3918/>`_
+      - `3.9.18 <https://www.python.org/downloads/release/python-3918/>`_
       - `1.4.0 <https://github.com/ROCm/apex/tree/release/1.4.0>`_
       - `0.19.0 <https://github.com/pytorch/vision/tree/v0.19.0>`_
-      - `2.13.0 <https://github.com/tensorflow/tensorboard/tree/2.13>`_
+      - `2.13.0 <https://github.com/tensorflow/tensorboard/tree/2.13.0>`_
       - `master <https://bitbucket.org/icl/magma/src/master/>`_
       - `1.10.0 <https://github.com/openucx/ucx/tree/v1.10.0>`_
       - `4.0.7 <https://github.com/open-mpi/ompi/tree/v4.0.7>`_
@@ -127,7 +129,7 @@ Click the |docker-icon| icon to view the image on Docker Hub.
       - `3.10 <https://www.python.org/downloads/release/python-31016/>`_
       - `1.3.0 <https://github.com/ROCm/apex/tree/release/1.3.0>`_
       - `0.18.0 <https://github.com/pytorch/vision/tree/v0.18.0>`_
-      - `2.13.0 <https://github.com/tensorflow/tensorboard/tree/2.13>`_
+      - `2.13.0 <https://github.com/tensorflow/tensorboard/tree/2.13.0>`_
       - `master <https://bitbucket.org/icl/magma/src/master/>`_
       - `1.14.1 <https://github.com/openucx/ucx/tree/v1.14.1>`_
       - `4.1.5 <https://github.com/open-mpi/ompi/tree/v4.1.5>`_
@@ -142,7 +144,7 @@ Click the |docker-icon| icon to view the image on Docker Hub.
       - `3.10 <https://www.python.org/downloads/release/python-31016/>`_
       - `1.2.0 <https://github.com/ROCm/apex/tree/release/1.2.0>`_
       - `0.17.1 <https://github.com/pytorch/vision/tree/v0.17.1>`_
-      - `2.13.0 <https://github.com/tensorflow/tensorboard/tree/2.13>`_
+      - `2.13.0 <https://github.com/tensorflow/tensorboard/tree/2.13.0>`_
       - `master <https://bitbucket.org/icl/magma/src/master/>`_
       - `1.14.1 <https://github.com/openucx/ucx/tree/v1.14.1>`_
       - `4.1.5 <https://github.com/open-mpi/ompi/tree/v4.1.5>`_
@@ -154,7 +156,7 @@ Click the |docker-icon| icon to view the image on Docker Hub.
 
       - `2.2.1 <https://github.com/ROCm/pytorch/tree/release/2.2>`_
       - 20.04
-      - `3.9 <https://www.python.org/downloads/release/python-3921/>`_
+      - `3.9.21 <https://www.python.org/downloads/release/python-3921/>`_
       - `1.2.0 <https://github.com/ROCm/apex/tree/release/1.2.0>`_
       - `0.17.1 <https://github.com/pytorch/vision/tree/v0.17.1>`_
       - `2.13.0 <https://github.com/tensorflow/tensorboard/tree/2.13.0>`_
@@ -169,7 +171,7 @@ Click the |docker-icon| icon to view the image on Docker Hub.
 
       - `1.13.1 <https://github.com/ROCm/pytorch/tree/release/1.13>`_
       - 22.04
-      - `3.9 <https://www.python.org/downloads/release/python-3921/>`_
+      - `3.9.21 <https://www.python.org/downloads/release/python-3921/>`_
       - `1.0.0 <https://github.com/ROCm/apex/tree/release/1.0.0>`_
       - `0.14.0 <https://github.com/pytorch/vision/tree/v0.14.0>`_
       - `2.18.0 <https://github.com/tensorflow/tensorboard/tree/2.18>`_
@@ -184,7 +186,7 @@ Click the |docker-icon| icon to view the image on Docker Hub.
 
       - `1.13.1 <https://github.com/ROCm/pytorch/tree/release/1.13>`_
       - 20.04
-      - `3.9 <https://www.python.org/downloads/release/python-3921/>`_
+      - `3.9.21 <https://www.python.org/downloads/release/python-3921/>`_
       - `1.0.0 <https://github.com/ROCm/apex/tree/release/1.0.0>`_
       - `0.14.0 <https://github.com/pytorch/vision/tree/v0.14.0>`_
       - `2.18.0 <https://github.com/tensorflow/tensorboard/tree/2.18>`_
@@ -213,7 +215,7 @@ performance, and feature set available to developers.
         (GEMM), convolutions and transformations.
       - Speeds up ``torch.permute``, ``torch.view``, ``torch.matmul``,
         ``torch.mm``, ``torch.bmm``, ``torch.nn.Conv2d``, ``torch.nn.Conv3d``
-        and ``torch.nn.MultiheadAttention``. 
+        and ``torch.nn.MultiheadAttention``.
     * - `hipBLAS <https://github.com/ROCm/hipBLAS>`_
       - 2.3.0
       - Provides GPU-accelerated Basic Linear Algebra Subprograms (BLAS) for
@@ -243,7 +245,7 @@ performance, and feature set available to developers.
     * - `hipRAND <https://github.com/ROCm/hipRAND>`_
       - 2.11.0
       - Provides fast random number generation for GPUs.
-      - The ``torch.rand``, ``torch.randn`` and stochastic layers like 
+      - The ``torch.rand``, ``torch.randn`` and stochastic layers like
         ``torch.nn.Dropout``.
     * - `hipSOLVER <https://github.com/ROCm/hipSOLVER>`_
       - 2.3.0
@@ -865,7 +867,7 @@ The following are GPU-accelerated PyTorch features not currently supported by RO
     * - ``torch.backends.cuda`` / ``matmul.allow_bf16_reduced_precision_reduction``
       - Reduced precision reductions are allowed with bf16 GEMMs.
       - 2.0
-    * - ``torch.nn.functional`` / ``scaled_dot_product_attention`` 
+    * - ``torch.nn.functional`` / ``scaled_dot_product_attention``
       - Flash attention backend for SDPA to accelerate attention computation in
         transformer-based models.
       - 2.0

--- a/docs/compatibility/ml-compatibility/tensorflow-compatibility.rst
+++ b/docs/compatibility/ml-compatibility/tensorflow-compatibility.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. meta::
     :description: TensorFlow compatibility
     :keywords: GPU, TensorFlow compatibility
@@ -49,8 +51,8 @@ Docker image compatibility
 
    <i class="fab fa-docker"></i>
 
-AMD validates and publishes ready-made `TensorFlow
-<https://hub.docker.com/r/rocm/tensorflow>`_ images with ROCm backends on
+AMD validates and publishes ready-made `TensorFlow images
+<https://hub.docker.com/r/rocm/tensorflow>`_ with ROCm backends on
 Docker Hub. The following Docker image tags and associated inventories are
 validated for `ROCm 6.3.1 <https://repo.radeon.com/rocm/apt/6.3.1/>`_. Click
 the |docker-icon| icon to view the image on Docker Hub.
@@ -62,13 +64,13 @@ the |docker-icon| icon to view the image on Docker Hub.
       - TensorFlow
       - Dev
       - Python
-      - TensorBoard 
+      - TensorBoard
 
     * - .. raw:: html
 
            <a href="https://hub.docker.com/layers/rocm/tensorflow/rocm6.3.1-py3.12-tf2.17.0-dev/images/sha256-804121ee4985718277ba7dcec53c57bdade130a1ef42f544b6c48090ad379c17"><i class="fab fa-docker fa-lg"></i> rocm/tensorflow</a>
 
-      - `tensorflow-rocm 2.17.0 <https://repo.radeon.com/rocm/manylinux/rocm-rel-6.3/tensorflow_rocm-2.17.0-cp312-cp312-manylinux_2_28_x86_64.whl>`_
+      - `tensorflow-rocm 2.17.0 <https://repo.radeon.com/rocm/manylinux/rocm-rel-6.3/tensorflow_rocm-2.17.0-cp312-cp312-manylinux_2_28_x86_64.whl>`__
       - dev
       - `Python 3.12 <https://www.python.org/downloads/release/python-3124/>`_
       - `TensorBoard 2.17.1 <https://github.com/tensorflow/tensorboard/tree/2.17.1>`_
@@ -77,7 +79,7 @@ the |docker-icon| icon to view the image on Docker Hub.
 
            <a href="https://hub.docker.com/layers/rocm/tensorflow/rocm6.3.1-py3.10-tf2.17.0-dev/images/sha256-776837ffa945913f6c466bfe477810a11453d21d5b6afb200be1c36e48fbc08e"><i class="fab fa-docker fa-lg"></i> rocm/tensorflow</a>
 
-      - `tensorflow-rocm 2.17.0 <https://repo.radeon.com/rocm/manylinux/rocm-rel-6.3/tensorflow_rocm-2.17.0-cp310-cp310-manylinux_2_28_x86_64.whl>`_
+      - `tensorflow-rocm 2.17.0 <https://repo.radeon.com/rocm/manylinux/rocm-rel-6.3/tensorflow_rocm-2.17.0-cp310-cp310-manylinux_2_28_x86_64.whl>`__
       - dev
       - `Python 3.10 <https://www.python.org/downloads/release/python-31012/>`_
       - `TensorBoard 2.17.0 <https://github.com/tensorflow/tensorboard/tree/2.17.0>`_
@@ -86,7 +88,7 @@ the |docker-icon| icon to view the image on Docker Hub.
 
            <a href="https://hub.docker.com/layers/rocm/tensorflow/rocm6.3.1-py3.12-tf2.16.2-dev/images/sha256-c793e1483e30809c3c28fc5d7805bedc033c73da224f839fff370717cb100944"><i class="fab fa-docker fa-lg"></i> rocm/tensorflow</a>
 
-      - `tensorflow-rocm 2.16.2 <https://repo.radeon.com/rocm/manylinux/rocm-rel-6.3/tensorflow_rocm-2.16.2-cp312-cp312-manylinux_2_28_x86_64.whl>`_
+      - `tensorflow-rocm 2.16.2 <https://repo.radeon.com/rocm/manylinux/rocm-rel-6.3/tensorflow_rocm-2.16.2-cp312-cp312-manylinux_2_28_x86_64.whl>`__
       - dev
       - `Python 3.12 <https://www.python.org/downloads/release/python-3124/>`_
       - `TensorBoard 2.16.2 <https://github.com/tensorflow/tensorboard/tree/2.16.2>`_
@@ -95,7 +97,7 @@ the |docker-icon| icon to view the image on Docker Hub.
 
            <a href="https://hub.docker.com/layers/rocm/tensorflow/rocm6.3.1-py3.10-tf2.16.0-dev/images/sha256-263e78414ae85d7bcd52a025a94131d0a279872a45ed632b9165336dfdcd4443"><i class="fab fa-docker fa-lg"></i> rocm/tensorflow</a>
 
-      - `tensorflow-rocm 2.16.2 <https://repo.radeon.com/rocm/manylinux/rocm-rel-6.3/tensorflow_rocm-2.16.2-cp310-cp310-manylinux_2_28_x86_64.whl>`_
+      - `tensorflow-rocm 2.16.2 <https://repo.radeon.com/rocm/manylinux/rocm-rel-6.3/tensorflow_rocm-2.16.2-cp310-cp310-manylinux_2_28_x86_64.whl>`__
       - dev
       - `Python 3.10 <https://www.python.org/downloads/release/python-31012/>`_
       - `TensorBoard 2.16.2 <https://github.com/tensorflow/tensorboard/tree/2.16.2>`_
@@ -359,9 +361,9 @@ availability in ROCm.
       - 1.13
       - 2.1
     * - ``tf.data`` (Data Input Pipeline)
-      - GPU-accelerated data preprocessing for efficient input pipelines, 
+      - GPU-accelerated data preprocessing for efficient input pipelines,
         Prefetching with ``tf.data.experimental.AUTOTUNE``. GPU-enabled
-        transformations like map and batch. 
+        transformations like map and batch.
       - 1.4
       - 1.8.2
     * - ``tf.distribute`` (Distributed Training)
@@ -396,7 +398,7 @@ availability in ROCm.
       - 2.4
     * - ``tf.quantization``
       - Quantized operations for inference, accelerated on GPUs.
-      - 1.12 
+      - 1.12
       - 1.9.2
 
 Distributed library features

--- a/docs/conceptual/ai-pytorch-inception.md
+++ b/docs/conceptual/ai-pytorch-inception.md
@@ -53,7 +53,7 @@ The following sections contain case studies for the Inception V3 model.
 
 ### Inception V3 with PyTorch
 
-Convolution Neural Networks are forms of artificial neural networks commonly used for image processing. One of the core layers of such a network is the convolutional layer, which convolves the input with a weight tensor and passes the result to the next layer. Inception V3[^inception_arch] is an architectural development over the ImageNet competition-winning entry, AlexNet, using more profound and broader networks while attempting to meet computational and memory budgets.
+Convolution Neural Networks are forms of artificial neural networks commonly used for image processing. One of the core layers of such a network is the convolutional layer, which convolves the input with a weight tensor and passes the result to the next layer. Inception V3 is an architectural development over the ImageNet competition-winning entry, AlexNet, using more profound and broader networks while attempting to meet computational and memory budgets.
 
 The implementation uses PyTorch as a framework. This case study utilizes [TorchVision](https://pytorch.org/vision/stable/index.html), a repository of popular datasets and model architectures, for obtaining the model. TorchVision also provides pre-trained weights as a starting point to develop new models or fine-tune the model for a new task.
 
@@ -162,7 +162,7 @@ Follow these steps:
     docker run -it --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --device=/dev/kfd --device=/dev/dri --group-add video --ipc=host --shm-size 8G rocm/pytorch:latest
     ```
 
-2. Download an ImageNet database. For this example, the `tiny-imagenet-200`[^Stanford_deep_learning], a smaller ImageNet variant with 200 image classes and a training dataset with 100,000 images, was downsized to 64x64 color images.
+2. Download an ImageNet database. For this example, the `tiny-imagenet-200`, a smaller ImageNet variant with 200 image classes and a training dataset with 100,000 images, was downsized to 64x64 color images.
 
     ```bash
     wget http://cs231n.stanford.edu/tiny-imagenet-200.zip
@@ -366,7 +366,7 @@ Follow these steps:
     model.to(device)
     ```
 
-13. Set the loss criteria. For this example, Cross Entropy Loss[^cross_entropy] is used.
+13. Set the loss criteria. For this example, Cross Entropy Loss is used.
 
     ```py
     criterion = torch.nn.CrossEntropyLoss()
@@ -586,7 +586,7 @@ Follow these steps:
     import torch.optim as optim
     ```
 
-10. Set the loss criteria. For this example, Cross Entropy Loss[^cross_entropy] is used.
+10. Set the loss criteria. For this example, Cross Entropy Loss is used.
 
     ```py
     criterion = nn.CrossEntropyLoss()

--- a/docs/how-to/programming_guide.rst
+++ b/docs/how-to/programming_guide.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. meta::
     :description: Programming guide
     :keywords: HIP, programming guide, heterogeneous programming, AMD GPU programming
@@ -12,7 +14,7 @@ ROCm provides a robust environment for heterogeneous programs running on CPUs
 and AMD GPUs. ROCm supports various programming languages and frameworks to
 help developers access the power of AMD GPUs. The natively supported programming
 languages are HIP (Heterogeneous-Compute Interface for Portability) and
-OpenCL, but HIP bindings are available for Python and Fortran. 
+OpenCL, but HIP bindings are available for Python and Fortran.
 
 HIP is an API based on C++ that provides a runtime and kernel language for GPU
 programming and is the essential ROCm programming language. HIP is also designed

--- a/docs/how-to/rocm-for-hpc/index.rst
+++ b/docs/how-to/rocm-for-hpc/index.rst
@@ -20,7 +20,7 @@ applications.
 * For more information, see :doc:`What is ROCm? <../../what-is-rocm>`.
 
 * For guidance on installing ROCm, see :doc:`rocm-install-on-linux:index`. See
-  the :doc:`../../compatibility/compatibility-matrix` for details on hardware
+  the :doc:`Compatibility matrix <../../compatibility/compatibility-matrix>` for details on hardware
   and operating system support.
 
 Some of the most popular HPC frameworks are part of the ROCm platform, including
@@ -32,7 +32,7 @@ handle memory hierarchies, and solve linear systems.
    :alt: Software and hardware ecosystem surrounding ROCm and AMD Instinct for HPC
 
 The following catalog of GPU-accelerated solutions includes a vast set of
-platform-compatible HPC applications, including those for astrophysics, climate 
+platform-compatible HPC applications, including those for astrophysics, climate
 and weather, computational chemistry, computational fluid dynamics, earth
 science, genomics, geophysics, molecular dynamics, and physics computing.
 
@@ -116,11 +116,11 @@ Ubuntu versions.
 
       * - Molecular dynamics
         - `Amber <https://github.com/amd/InfinityHub-CI/tree/main/amber>`_
-        - Amber is a suite of biomolecular simulation programs. It is a set of molecular mechanical force fields for 
-          simulating biomolecules. Amber is also a package of molecular simulation 
+        - Amber is a suite of biomolecular simulation programs. It is a set of molecular mechanical force fields for
+          simulating biomolecules. Amber is also a package of molecular simulation
           programs which includes source code and demos.
 
-      * - 
+      * -
         - `GROMACS with HIP (AMD implementation) <https://github.com/amd/InfinityHub-CI/tree/main/gromacs>`_
         - GROMACS is a versatile package to perform molecular dynamics, i.e.
           simulate the Newtonian equations of motion for systems with hundreds
@@ -136,9 +136,9 @@ Ubuntu versions.
 
       * - Computational fluid dynamics
         - `Ansys Fluent <https://github.com/amd/InfinityHub-CI/tree/main/ansys-fluent>`_
-        - Ansys Fluent is an advanced computational fluid dynamics (CFD) tool for 
-          simulating and analyzing fluid flow, heat transfer, and related phenomena in complex systems. 
-          It offers a range of powerful features for detailed and accurate modeling of various physical 
+        - Ansys Fluent is an advanced computational fluid dynamics (CFD) tool for
+          simulating and analyzing fluid flow, heat transfer, and related phenomena in complex systems.
+          It offers a range of powerful features for detailed and accurate modeling of various physical
           processes, including turbulence, chemical reactions, and multiphase flows.
 
       * -
@@ -152,15 +152,15 @@ Ubuntu versions.
       * -
         - `nekRS <https://github.com/amd/InfinityHub-CI/tree/main/nekrs>`_
         - nekRS is an open-source Navier Stokes solver based on the spectral element
-          method targeting classical processors and accelerators like GPUs. 
+          method targeting classical processors and accelerators like GPUs.
 
       * -
         - `OpenFOAM <https://github.com/amd/InfinityHub-CI/tree/main/openfoam>`_
-        - OpenFOAM is a free, open-source computational fluid dynamics (CFD) 
-          tool developed primarily by OpenCFD Ltd. It has a large user 
-          base across most areas of engineering and science, from both commercial and 
-          academic organizations. OpenFOAM has extensive features to solve 
-          anything from complex fluid flows involving chemical reactions, turbulence, and 
+        - OpenFOAM is a free, open-source computational fluid dynamics (CFD)
+          tool developed primarily by OpenCFD Ltd. It has a large user
+          base across most areas of engineering and science, from both commercial and
+          academic organizations. OpenFOAM has extensive features to solve
+          anything from complex fluid flows involving chemical reactions, turbulence, and
           heat transfer, to acoustics, solid mechanics, and electromagnetics.
 
       * -
@@ -169,9 +169,9 @@ Ubuntu versions.
 
       * -
         - `Simcenter Star-CCM+ <https://github.com/amd/InfinityHub-CI/tree/main/siemens-star-ccm>`_
-        - Simcenter Star-CCM+ is a comprehensive computational fluid dynamics (CFD) and multiphysics 
-          simulation tool developed by Siemens Digital Industries Software. It is designed to 
-          help engineers and researchers analyze and optimize the performance of products and 
+        - Simcenter Star-CCM+ is a comprehensive computational fluid dynamics (CFD) and multiphysics
+          simulation tool developed by Siemens Digital Industries Software. It is designed to
+          help engineers and researchers analyze and optimize the performance of products and
           systems across various industries.
 
       * - Computational chemistry
@@ -205,27 +205,27 @@ Ubuntu versions.
 
       * - Energy, Oil, and Gas
         - `DevitoPRO <https://github.com/amd/InfinityHub-CI/tree/main/devitopro>`_
-        - DevitoPRO is an advanced extension of the open-source Devito platform with added 
+        - DevitoPRO is an advanced extension of the open-source Devito platform with added
           features tailored for high-demand production workflows. It supports
-          high-performance computing (HPC) needs, especially in seismic imaging and inversion. 
-          It is used to perform optimized finite difference (FD) computations 
-          from high-level symbolic problem definitions. DevitoPro performs automated 
-          code generation and Just-In-time (JIT) compilation based on symbolic equations 
-          defined in SymPy to create and execute highly optimized Finite Difference stencil 
+          high-performance computing (HPC) needs, especially in seismic imaging and inversion.
+          It is used to perform optimized finite difference (FD) computations
+          from high-level symbolic problem definitions. DevitoPro performs automated
+          code generation and Just-In-time (JIT) compilation based on symbolic equations
+          defined in SymPy to create and execute highly optimized Finite Difference stencil
           kernels on multiple computer platforms.
 
-      * - 
+      * -
         - `ECHELON <https://github.com/amd/InfinityHub-CI/tree/main/srt-echelon>`_
-        - ECHELON by Stone Ridge Technology is a reservoir simulation tool. With 
-          fast processing, it retains precise accuracy and preserves legacy simulator results. 
-          Faster reservoir simulation enables reservoir engineers to produce many realizations, 
-          address larger models, and use advanced physics. It opens new workflows based on 
-          ensemble methodologies for history matching and forecasting that yield 
+        - ECHELON by Stone Ridge Technology is a reservoir simulation tool. With
+          fast processing, it retains precise accuracy and preserves legacy simulator results.
+          Faster reservoir simulation enables reservoir engineers to produce many realizations,
+          address larger models, and use advanced physics. It opens new workflows based on
+          ensemble methodologies for history matching and forecasting that yield
           increased accuracy and more predictive results.
 
       * - Benchmark
         - `rocHPL <https://github.com/amd/InfinityHub-CI/tree/main/rochpl>`_
-        - HPL, or High-Performance Linpack, is a benchmark which solves a uniformly 
+        - HPL, or High-Performance Linpack, is a benchmark which solves a uniformly
           random system of linear equations and reports floating-point execution rate.
 
       * -
@@ -269,10 +269,10 @@ Ubuntu versions.
 
       * -
         - `PETSc <https://github.com/amd/InfinityHub-CI/tree/main/petsc>`_
-        - Portable, Extensible Toolkit for Scientific Computation (PETSc) is a suite of data structures 
-          and routines for the scalable (parallel) solution of scientific applications modeled by partial 
-          differential equations. It supports MPI, GPUs through CUDA, HIP, and OpenCL, 
-          as well as hybrid MPI-GPU parallelism. It also supports the NEC-SX Tsubasa Vector Engine. 
+        - Portable, Extensible Toolkit for Scientific Computation (PETSc) is a suite of data structures
+          and routines for the scalable (parallel) solution of scientific applications modeled by partial
+          differential equations. It supports MPI, GPUs through CUDA, HIP, and OpenCL,
+          as well as hybrid MPI-GPU parallelism. It also supports the NEC-SX Tsubasa Vector Engine.
           PETSc also includes the Toolkit for Advanced Optimization (TAO) library.
 
       * -

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ ROCm documentation is organized into the following categories:
 * [System debugging](./how-to/system-debugging.md)
 * [Use advanced compiler features](./conceptual/compiler-topics.md)
 * [Set the number of CUs](./how-to/setting-cus)
-* [Troubleshoot BAR access limitation](./how-to/Bar-Memory.rst)  
+* [Troubleshoot BAR access limitation](./how-to/Bar-Memory.rst)
 * [ROCm examples](https://github.com/amd/rocm-examples)
 :::
 
@@ -62,16 +62,15 @@ ROCm documentation is organized into the following categories:
 * [Oversubscription of hardware resources](./conceptual/oversubscription.rst)
 :::
 
-<!-- markdownlint-disable MD051 -->
 :::{grid-item-card} Reference
 :class-body: rocm-card-banner rocm-hue-6
-
+<!-- markdownlint-disable MD051 -->
 * [ROCm libraries](./reference/api-libraries.md)
 * [ROCm tools, compilers, and runtimes](./reference/rocm-tools.md)
 * [Accelerator and  GPU hardware specifications](./reference/gpu-arch-specs.rst)
 * [Precision support](./reference/precision-support.rst)
 * [Graph safe support](./reference/graph-safe-support.rst)
-:::
 <!-- markdownlint-enable MD051 -->
+:::
 
 ::::

--- a/docs/reference/api-libraries.md
+++ b/docs/reference/api-libraries.md
@@ -12,10 +12,10 @@
 :gutter: 3
 :class-container: rocm-doc-grid
 
-(artificial-intelligence-apis)=
-
 :::{grid-item-card} Machine Learning and Computer Vision
 :class-body: rocm-card-banner rocm-hue-3
+
+(artificial-intelligence-apis)=
 
 * {doc}`Composable Kernel <composable_kernel:index>`
 * {doc}`MIGraphX <amdmigraphx:index>`
@@ -28,10 +28,10 @@
 * {doc}`ROCm Performance Primitives (RPP) <rpp:index>`
 :::
 
-(cpp-primitives)=
-
 :::{grid-item-card} Primitives
 :class-body: rocm-card-banner rocm-hue-12
+
+(cpp-primitives)=
 
 * {doc}`hipCUB <hipcub:index>`
 * {doc}`hipTensor <hiptensor:index>`
@@ -39,18 +39,18 @@
 * {doc}`rocThrust <rocthrust:index>`
 :::
 
-(communication-libraries)=
-
 :::{grid-item-card} Communication
 :class-body: rocm-card-banner rocm-hue-7
+
+(communication-libraries)=
 
 * {doc}`RCCL <rccl:index>`
 :::
 
-(math-apis)=
-
 :::{grid-item-card} Math
 :class-body: rocm-card-banner rocm-hue-6
+
+(math-apis)=
 
 * [half](https://github.com/ROCm/half)
 * {doc}`hipBLAS <hipblas:index>` / {doc}`rocBLAS <rocblas:index>`

--- a/docs/reference/precision-support.rst
+++ b/docs/reference/precision-support.rst
@@ -467,7 +467,7 @@ description, refer to the corresponding library data type support page.
         - ❌/❌
         - ❌/❌
       *
-        - rocRAND (:doc:`details <rocrand:data-type-support>`)
+        - rocRAND (:doc:`details <rocrand:api-reference/data-type-support>`)
         - -/❌
         - -/❌
         - -/✅

--- a/docs/reference/rocm-tools.md
+++ b/docs/reference/rocm-tools.md
@@ -12,10 +12,10 @@
 :gutter: 3
 :class-container: rocm-doc-grid
 
-(system-tools)=
-
 :::{grid-item-card} System Management
 :class-body: rocm-card-banner rocm-hue-1
+
+(system-tools)=
 
 * {doc}`AMD SMI <amdsmi:index>`
 * {doc}`ROCm Data Center Tool <rdc:index>`
@@ -24,10 +24,10 @@
 * {doc}`ROCm Validation Suite <rocmvalidationsuite:index>`
 :::
 
-(performance-tools)=
-
 :::{grid-item-card} Performance
 :class-body: rocm-card-banner rocm-hue-6
+
+(performance-tools)=
 
 * {doc}`ROCm Bandwidth Test <rocm_bandwidth_test:index>`
 * {doc}`ROCm Compute Profiler <rocprofiler-compute:index>`
@@ -37,10 +37,10 @@
 * {doc}`ROCTracer <roctracer:index>`
 :::
 
-(development-tools)=
-
 :::{grid-item-card} Development
 :class-body: rocm-card-banner rocm-hue-1
+
+(development-tools)=
 
 * {doc}`ROCm CMake <rocmcmakebuildtools:index>`
 * {doc}`HIPIFY <hipify:index>`
@@ -49,20 +49,20 @@
 * {doc}`ROCr Debug Agent <rocr_debug_agent:index>`
 :::
 
-(compilers)=
-
 :::{grid-item-card} Compilers
 :class-body: rocm-card-banner rocm-hue-8
+
+(compilers)=
 
 * {doc}`ROCm Compilers <llvm-project:index>`
 * {doc}`HIPCC <hipcc:index>`
 * [FLANG](https://github.com/ROCm/flang/)
 :::
 
-(runtimes)=
-
 :::{grid-item-card} Runtimes
 :class-body: rocm-card-banner rocm-hue-12
+
+(runtimes)=
 
 * {doc}`AMD Compute Language Runtime (CLR) <hip:understand/amd_clr>`
 * {doc}`HIP <hip:index>`

--- a/docs/release/versions.md
+++ b/docs/release/versions.md
@@ -1,3 +1,5 @@
+:orphan:
+
 <head>
   <meta charset="UTF-8">
   <meta name="description" content="ROCm release history">


### PR DESCRIPTION
The following PR addresses the warnings (and some errors) from the sphinx build output:
- Duplicate target names
  - Some links were edited to have unique names according to the context
  - Some links were fixed to ensure the same target
  - In the case of the links under the tensorflow-compatibility.rst page, the following [solution](https://www.tarantool.io/en/doc/latest/contributing/docs/sphinx-warnings/#duplicate-explicit-target-name) was used to ensure visual consistency rather than applying a unique name
- `:orphan:` was added to files that are not listed within the main toctree, but are accessible via other pages
- Some errors were produced due to labels being placed outside `{grid-item-card}`; those labels have been moved into the cards
- In `docs/conceptual/ai-pytorch-inception.md`, there were some labels that were causing warnings (e.g. `[înception_arch]`), I'm not sure if they were meant to link somewhere, but even on the official docs page they weren't being displayed properly. I've removed them but would appreciate feedback

Some trimming was applied to the files that were changed.