### PR TITLE
Fix link to Llama recipes

### DIFF
--- a/docs/how-to/rocm-for-ai/scale-model-training.rst
+++ b/docs/how-to/rocm-for-ai/scale-model-training.rst
@@ -132,4 +132,4 @@ The following developer blogs showcase examples of fine-tuning a model on an AMD
 * Recipes for fine-tuning Llama2 and 3 with ``llama-recipes``
 
   * `meta-llama/llama-recipes: Scripts for fine-tuning Meta Llama3 with composable FSDP & PEFT methods to cover
-    single/multi-node GPUs <https://github.com/meta-llama/llama-recipes/tree/main/recipes/quickstart/finetuning>`_
+    single/multi-node GPUs <https://github.com/meta-llama/llama-cookbook/tree/main/getting-started/finetuning>`_


### PR DESCRIPTION
Fix link due to moved files in https://github.com/meta-llama/llama-cookbook/commit/ae010af7d86d2d4589250ba57ed519356f8e5d25