### PR TITLE
Add spellcheck configuration

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,13 +2,13 @@ name: Linting
 
 on:
   push:
-    branches: 
+    branches:
     - develop
     - main
     - 'docs/*'
     - 'roc**'
   pull_request:
-    branches: 
+    branches:
     - develop
     - main
     - 'docs/*'

--- a/.spellcheck.local.yaml
+++ b/.spellcheck.local.yaml
@@ -1,0 +1,10 @@
+matrix:
+- name: Markdown
+  sources:
+  - ['tools/autotag/templates/**/*.md', '!tools/autotag/templates/**/5*.md', '!tools/autotag/templates/**/6.0*.md', '!tools/autotag/templates/**/6.1*.md']
+- name: reST
+  sources:
+  - []
+- name: Cpp
+  sources:
+  - []


### PR DESCRIPTION
This PR depends on https://github.com/ROCm/rocm-docs-core/pull/1100

Once the above is merged in, the `linting.yml` file will be updated to target the proper branch.

This PR adds a local spellcheck file that adds all C++ files from `include/hip` for the C++ spellchecking workflow (for now the spellchecking ignores all block and line comments).