### PR TITLE
[docs/6.3.1] fix link to llama cookbook (#4269)

### DIFF
--- a/docs/how-to/rocm-for-ai/scale-model-training.rst
+++ b/docs/how-to/rocm-for-ai/scale-model-training.rst
@@ -132,4 +132,4 @@ The following developer blogs showcase examples of fine-tuning a model on an AMD
 * Recipes for fine-tuning Llama2 and 3 with ``llama-recipes``
 
   * `meta-llama/llama-recipes: Scripts for fine-tuning Meta Llama3 with composable FSDP & PEFT methods to cover
-    single/multi-node GPUs <https://github.com/meta-llama/llama-recipes/tree/main/recipes/quickstart/finetuning>`_
+    single/multi-node GPUs <https://github.com/meta-llama/llama-cookbook/tree/main/getting-started/finetuning>`_


### PR DESCRIPTION
(cherry picked from commit 8dd99fe3a4217b656f0fc4685c77b50e3f027e69)