### PR TITLE
External CI: pull mainline dependencies for mainline CI builds

### DIFF
--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -392,17 +392,17 @@ steps:
         # dependencySource = mainline
         ${{ elseif eq(parameters.dependencySource, 'mainline')}}:
           branchName: ${{ parameters.componentVarList[dependency].mainlineBranch }}
-        # checkoutRef = staging
-        ${{ elseif eq(parameters.checkoutRef, parameters.componentVarList[variables['Build.DefinitionName']].stagingBranch) }}:
-          branchName: ${{ parameters.componentVarList[dependency].stagingBranch }}
-        # checkoutRef = mainline
-        ${{ elseif eq(parameters.checkoutRef, parameters.componentVarList[variables['Build.DefinitionName']].mainlineBranch) }}:
-          branchName: ${{ parameters.componentVarList[dependency].mainlineBranch }}
+        # # checkoutRef = staging
+        # ${{ elseif eq(parameters.checkoutRef, parameters.componentVarList[variables['Build.DefinitionName']].stagingBranch) }}:
+        #   branchName: ${{ parameters.componentVarList[dependency].stagingBranch }}
+        # # checkoutRef = mainline
+        # ${{ elseif eq(parameters.checkoutRef, parameters.componentVarList[variables['Build.DefinitionName']].mainlineBranch) }}:
+        #   branchName: ${{ parameters.componentVarList[dependency].mainlineBranch }}
         # SourceBranchName = staging
         ${{ elseif eq(variables['Build.SourceBranchName'], parameters.componentVarlist[variables['Build.DefinitionName']].stagingBranch) }}:
           branchName: ${{ parameters.componentVarList[dependency].stagingBranch }}
         # SourceBranchName = mainline
-        ${{ elseif eq(variables['Build.SourceBranchName'], parameters.componentVarlist[variables['Build.DefinitionName']].mainlineBranch) }}:
+        ${{ elseif eq(variables['Build.SourceBranchName'], 'self-ref') }}:
           branchName: ${{ parameters.componentVarList[dependency].mainlineBranch }}
         # default = staging
         ${{ else }}:

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -392,14 +392,14 @@ steps:
         # dependencySource = mainline
         ${{ elseif eq(parameters.dependencySource, 'mainline')}}:
           branchName: ${{ parameters.componentVarList[dependency].mainlineBranch }}
-        # # checkoutRef = staging
-        # ${{ elseif eq(parameters.checkoutRef, parameters.componentVarList[variables['Build.DefinitionName']].stagingBranch) }}:
-        #   branchName: ${{ parameters.componentVarList[dependency].stagingBranch }}
-        # # checkoutRef = mainline
-        # ${{ elseif eq(parameters.checkoutRef, parameters.componentVarList[variables['Build.DefinitionName']].mainlineBranch) }}:
-        #   branchName: ${{ parameters.componentVarList[dependency].mainlineBranch }}
+        # checkoutRef = staging
+        ${{ elseif eq(parameters.checkoutRef, parameters.componentVarList[variables['Build.DefinitionName']].stagingBranch) }}:
+          branchName: ${{ parameters.componentVarList[dependency].stagingBranch }}
+        # checkoutRef = mainline
+        ${{ elseif eq(parameters.checkoutRef, parameters.componentVarList[variables['Build.DefinitionName']].mainlineBranch) }}:
+          branchName: ${{ parameters.componentVarList[dependency].mainlineBranch }}
         # SourceBranchName = staging
-        ${{ elseif eq(variables['Build.SourceBranchName'], 'self-ref') }}:
+        ${{ elseif eq(variables['Build.SourceBranchName'], parameters.componentVarlist[variables['Build.DefinitionName']].stagingBranch) }}:
           branchName: ${{ parameters.componentVarList[dependency].stagingBranch }}
         # SourceBranchName = mainline
         ${{ elseif eq(variables['Build.SourceBranchName'], parameters.componentVarlist[variables['Build.DefinitionName']].mainlineBranch) }}:

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -369,6 +369,12 @@ steps:
         # checkoutRef = mainline
         ${{ elseif eq(parameters.checkoutRef, parameters.componentVarList[variables['Build.DefinitionName']].mainlineBranch) }}:
           branchName: ${{ parameters.componentVarList[split(dependency, ':')[0]].mainlineBranch }}
+        # SourceBranchName = staging
+        ${{ elseif eq(variables['Build.SourceBranchName'], parameters.componentVarlist[variables['Build.DefinitionName']].stagingBranch) }}:
+          branchName: ${{ parameters.componentVarList[split(dependency, ':')[0]].stagingBranch }}
+        # SourceBranchName = mainline
+        ${{ elseif eq(variables['Build.SourceBranchName'], parameters.componentVarlist[variables['Build.DefinitionName']].mainlineBranch) }}:
+          branchName: ${{ parameters.componentVarList[split(dependency, ':')[0]].mainlineBranch }}
         # default = staging
         ${{ else }}:
           branchName: ${{ parameters.componentVarList[split(dependency, ':')[0]].stagingBranch }}
@@ -391,6 +397,12 @@ steps:
           branchName: ${{ parameters.componentVarList[dependency].stagingBranch }}
         # checkoutRef = mainline
         ${{ elseif eq(parameters.checkoutRef, parameters.componentVarList[variables['Build.DefinitionName']].mainlineBranch) }}:
+          branchName: ${{ parameters.componentVarList[dependency].mainlineBranch }}
+        # SourceBranchName = staging
+        ${{ elseif eq(variables['Build.SourceBranchName'], parameters.componentVarlist[variables['Build.DefinitionName']].stagingBranch) }}:
+          branchName: ${{ parameters.componentVarList[dependency].stagingBranch }}
+        # SourceBranchName = mainline
+        ${{ elseif eq(variables['Build.SourceBranchName'], parameters.componentVarlist[variables['Build.DefinitionName']].mainlineBranch) }}:
           branchName: ${{ parameters.componentVarList[dependency].mainlineBranch }}
         # default = staging
         ${{ else }}:

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -399,10 +399,10 @@ steps:
         # ${{ elseif eq(parameters.checkoutRef, parameters.componentVarList[variables['Build.DefinitionName']].mainlineBranch) }}:
         #   branchName: ${{ parameters.componentVarList[dependency].mainlineBranch }}
         # SourceBranchName = staging
-        ${{ elseif eq(variables['Build.SourceBranchName'], parameters.componentVarlist[variables['Build.DefinitionName']].stagingBranch) }}:
+        ${{ elseif eq(variables['Build.SourceBranchName'], 'self-ref') }}:
           branchName: ${{ parameters.componentVarList[dependency].stagingBranch }}
         # SourceBranchName = mainline
-        ${{ elseif eq(variables['Build.SourceBranchName'], 'self-ref') }}:
+        ${{ elseif eq(variables['Build.SourceBranchName'], parameters.componentVarlist[variables['Build.DefinitionName']].mainlineBranch) }}:
           branchName: ${{ parameters.componentVarList[dependency].mainlineBranch }}
         # default = staging
         ${{ else }}:


### PR DESCRIPTION
For CI triggered builds, `checkoutRef` is always blank, therefore CI builds would previously always pull staging dependencies. This PR adds an extra `Build.SourceBranchName` comparison into deps-rocm to allow CI mainline builds to pull mainline dependencies.

Azure docs ref: https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services

Example mainline build:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=19278