### PR TITLE
Cherry-pick to roc-6.3.x: Add ToC and index links to the AI Developer Tutorials (#4312)

### DIFF
--- a/docs/how-to/rocm-for-ai/fine-tuning/index.rst
+++ b/docs/how-to/rocm-for-ai/fine-tuning/index.rst
@@ -16,6 +16,9 @@ Throughout the following topics, this guide discusses the goals and :ref:`challe
 model <fine-tuning-llms-concept-challenge>` like Llama 2. In the
 sections that follow, you'll find practical guides on libraries and tools to accelerate your fine-tuning.
 
+The AI Developer Hub contains `AMD ROCm tutorials <https://rocm.docs.amd.com/projects/ai-developer-hub/en/latest/>`_ for
+training, fine-tuning, and inference. It leverages popular machine learning frameworks on AMD GPUs.
+
 - :doc:`Conceptual overview of fine-tuning LLMs <overview>`
 
 - :doc:`Fine-tuning and inference <fine-tuning-and-inference>` using a

--- a/docs/how-to/rocm-for-ai/index.rst
+++ b/docs/how-to/rocm-for-ai/index.rst
@@ -12,6 +12,9 @@ You can use ROCm to perform distributed training, which enables you to train mod
  
 Overall, ROCm can be used to improve the performance and efficiency of your AI applications. With its training, fine-tuning, and inference support, ROCm provides a complete solution for optimizing AI workflows and achieving the optimum results possible on AMD GPUs. 
 
+The AI Developer Hub contains `AMD ROCm tutorials <https://rocm.docs.amd.com/projects/ai-developer-hub/en/latest/>`_ for
+training, fine-tuning, and inference. It leverages popular machine learning frameworks on AMD GPUs.
+
 In this guide, you'll learn how to use ROCm for AI:
 
 - :doc:`Training <training/index>`

--- a/docs/how-to/rocm-for-ai/inference/index.rst
+++ b/docs/how-to/rocm-for-ai/inference/index.rst
@@ -11,6 +11,9 @@ Understanding the ROCm™ software platform’s architecture and capabilities is
 
 Throughout the following topics, this section provides a comprehensive guide to setting up and deploying AI inference on AMD GPUs. This includes instructions on how to install ROCm, how to use Hugging Face Transformers to manage pre-trained models for natural language processing (NLP) tasks, how to validate vLLM on AMD Instinct™ MI300X accelerators and illustrate how to deploy trained models in production environments. 
 
+The AI Developer Hub contains `AMD ROCm tutorials <https://rocm.docs.amd.com/projects/ai-developer-hub/en/latest/>`_ for
+training, fine-tuning, and inference. It leverages popular machine learning frameworks on AMD GPUs.
+
 - :doc:`Installing ROCm and machine learning frameworks <install>`
 
 - :doc:`Running models from Hugging Face <hugging-face-models>`

--- a/docs/how-to/rocm-for-ai/training/index.rst
+++ b/docs/how-to/rocm-for-ai/training/index.rst
@@ -14,6 +14,9 @@ Training models on AMD GPUs with the ROCm™ software platform allows you to use
  
 The ROCm software platform makes it easier to train models on AMD GPUs while maintaining compatibility with existing code and tools. The platform also provides features like multi-GPU support, allowing for scaling and parallelization of model training across multiple GPUs to enhance performance. 
 
+The AI Developer Hub contains `AMD ROCm tutorials <https://rocm.docs.amd.com/projects/ai-developer-hub/en/latest/>`_ for
+training, fine-tuning, and inference. It leverages popular machine learning frameworks on AMD GPUs.
+
 In this guide, you'll learn about:
 
 - :doc:`Training a model <train-a-model>`

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ ROCm documentation is organized into the following categories:
 :class-body: rocm-card-banner rocm-hue-12
 
 * [Use ROCm for AI](./how-to/rocm-for-ai/index.rst)
+* [AI tutorials](https://rocm.docs.amd.com/projects/ai-developer-hub/en/latest/)
 * [Use ROCm for HPC](./how-to/rocm-for-hpc/index.rst)
 * [System optimization](./how-to/system-optimization/index.rst)
 * [AMD Instinct MI300X performance validation and tuning](./how-to/tuning-guides/mi300x/index.rst)

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -89,7 +89,10 @@ subtrees:
             title: Profile and debug
           - file: how-to/rocm-for-ai/inference-optimization/workload.rst
             title: Workload tuning
-  
+
+      - url: https://rocm.docs.amd.com/projects/ai-developer-hub/en/latest/
+        title: AI tutorials
+
   - file: how-to/rocm-for-hpc/index.rst
     title: Use ROCm for HPC
   - file: how-to/system-optimization/index.rst
@@ -125,6 +128,7 @@ subtrees:
     title: Troubleshoot BAR access limitation  
   - url: https://github.com/amd/rocm-examples
     title: ROCm examples
+
 
 - caption: Conceptual
   entries:


### PR DESCRIPTION
* Add ToC and index links to the AI Developer Tutorials

* Change link positioning

* Change wording

(cherry picked from commit d401b5f1521c4b2db5b39300c3bf8585f67a53b1)