### PR TITLE
[roc-6.3.x] Fix merge conflict markers in vllm-benchmark.rst

### DIFF
--- a/docs/how-to/rocm-for-ai/inference/vllm-benchmark.rst
+++ b/docs/how-to/rocm-for-ai/inference/vllm-benchmark.rst
@@ -399,12 +399,9 @@ Further reading
 - To learn how to optimize inference on LLMs, see
   :doc:`Inference optimization <../inference-optimization/index>`.
 
-<<<<<<< HEAD:docs/how-to/performance-validation/mi300x/vllm-benchmark.rst
-=======
 - To learn how to fine-tune LLMs, see
   :doc:`Fine-tuning LLMs <../fine-tuning/index>`.
 
->>>>>>> develop:docs/how-to/rocm-for-ai/inference/vllm-benchmark.rst
 - To compare with the previous version of the ROCm vLLM Docker image for performance validation, refer to
   `LLM inference performance validation on AMD Instinct MI300X (ROCm 6.2.0) <https://rocm.docs.amd.com/en/docs-6.2.0/how-to/performance-validation/mi300x/vllm-benchmark.html>`_.
 


### PR DESCRIPTION
Fix merge conflict markers in vllm-benchmark.rst. For some reason, this only happened when syncing develop --> roc-6.3.x --> docs/6.3.2.

#4317 addresses roc-6.3.x