### PR TITLE
Ex CI: rocprof-sdk & rocprof-systems VCN tracing dependencies

### DIFF
--- a/.azuredevops/components/rocprofiler-sdk.yml
+++ b/.azuredevops/components/rocprofiler-sdk.yml
@@ -37,6 +37,8 @@ parameters:
     - clr
     - llvm-project
     - rccl
+    - rocDecode
+    - rocJPEG
     - rocm-cmake
     - rocm-core
     - rocminfo
@@ -99,6 +101,7 @@ jobs:
       aptPackages: ${{ parameters.aptPackages }}
       pipModules: ${{ parameters.pipModules }}
       gpuTarget: $(JOB_GPU_TARGET)
+      registerROCmPackages: true
 
 - job: rocprofiler_sdk_testing
   dependsOn: rocprofiler_sdk
@@ -155,3 +158,4 @@ jobs:
       pipModules: ${{ parameters.pipModules }}
       environment: test
       gpuTarget: $(JOB_GPU_TARGET)
+      registerROCmPackages: true

--- a/.azuredevops/components/rocprofiler-systems.yml
+++ b/.azuredevops/components/rocprofiler-systems.yml
@@ -46,13 +46,14 @@ parameters:
 - name: rocmDependencies
   type: object
   default:
+    - amdsmi
     - aomp
     - clr
     - llvm-project
     - rccl
     - rocDecode
+    - rocJPEG
     - rocm-core
-    - rocm_smi_lib
     - rocminfo
     - ROCR-Runtime
     - rocprofiler-register


### PR DESCRIPTION
Adds required ROCm dependencies to rocprofiler-sdk and rocprofiler-systems for their new VCN tracing capabilities.

rocprofiler-sdk log:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=19993&view=results

rocprofiler-systems log:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=19994&view=results