### PR TITLE
External CI: rocWMMA ROCM_PLATFORM_VERSION value set

### DIFF
--- a/.azuredevops/components/rocWMMA.yml
+++ b/.azuredevops/components/rocWMMA.yml
@@ -80,6 +80,7 @@ jobs:
         -DROCWMMA_BUILD_SAMPLES=OFF
         -DGPU_TARGETS=$(JOB_GPU_TARGET)
         -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
+        -DROCM_PLATFORM_VERSION=$(NEXT_RELEASE_VERSION)
         -GNinja
 # gfx1030 not supported in documentation
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml


### PR DESCRIPTION
- Set the value of this expected variable to fix build failures.
- [Build Log](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=20299&view=results)