### PR TITLE
External CI: Fix failures for rocprofiler-systems and ROCR-Runtime

### DIFF
--- a/.azuredevops/components/ROCR-Runtime.yml
+++ b/.azuredevops/components/ROCR-Runtime.yml
@@ -133,6 +133,7 @@ jobs:
           -DROCM_DIR=$(Agent.BuildDirectory)/rocm \
           -DLLVM_DIR=$(Agent.BuildDirectory)/rocm/llvm/bin \
           -DOPENCL_DIR=$(Agent.BuildDirectory)/rocm/llvm/bin
+          -DOPENCL_INC_DIR=$(Agent.BuildDirectory)/rocm/llvm/lib/clang/21/include
         make
         make rocrtst_kernels
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml

--- a/.azuredevops/components/rocprofiler-systems.yml
+++ b/.azuredevops/components/rocprofiler-systems.yml
@@ -55,9 +55,10 @@ parameters:
     - rocJPEG
     - rocm-core
     - rocminfo
-    - ROCR-Runtime
+    - rocm_smi_lib
     - rocprofiler-register
     - rocprofiler-sdk
+    - ROCR-Runtime
 
 jobs:
 - job: rocprofiler_systems


### PR DESCRIPTION
- Add rocm_smi_lib dependency to rocprofiler-systems.
- Explicitly set OPENCL_INC_DIR in ROCR-Runtime test job.