### PR TITLE
External CI: Fix ROCR common test suite build

### DIFF
--- a/.azuredevops/components/ROCR-Runtime.yml
+++ b/.azuredevops/components/ROCR-Runtime.yml
@@ -123,16 +123,12 @@ jobs:
       targetType: 'inline'
       workingDirectory: $(Build.SourcesDirectory)/rocrtst/suites/test_common
       script: |
-        sudo rm -rf $(Agent.BuildDirectory)/external/llvm-project
-        mkdir -p $(Agent.BuildDirectory)/external/llvm-project/clang/lib
-        sudo ln -s $(Agent.BuildDirectory)/rocm/llvm/lib/clang/20/include $(Agent.BuildDirectory)/external/llvm-project/clang/lib/Headers
         mkdir build && cd build
         cmake .. \
           -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm \
           -DTARGET_DEVICES=$(JOB_GPU_TARGET) \
           -DROCM_DIR=$(Agent.BuildDirectory)/rocm \
           -DLLVM_DIR=$(Agent.BuildDirectory)/rocm/llvm/bin \
-          -DOPENCL_DIR=$(Agent.BuildDirectory)/rocm/llvm/bin
           -DOPENCL_INC_DIR=$(Agent.BuildDirectory)/rocm/llvm/lib/clang/21/include
         make
         make rocrtst_kernels


### PR DESCRIPTION
- Removing the creation of expected folders and symbolic links as workaround to get the test components compiling.
- Set the only OpenCL build flag affecting the build.
- TODO: Add logic to automatically determine the version of clang that has the lib directory. For example, 21.
- [Passing Build Log](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=20626&view=results)