### PR TITLE
Ex CI: set ROCM_PATH for MIOpen tests

### DIFF
--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -101,7 +101,7 @@ jobs:
         -DMIOPEN_BACKEND=HIP
         -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
         -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/miopen-deps
-        -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
+        -DGPU_TARGETS=$(JOB_GPU_TARGET)
         -DMIOPEN_ENABLE_AI_KERNEL_TUNING=OFF
         -DMIOPEN_ENABLE_AI_IMMED_MODE_FALLBACK=OFF
         -DCMAKE_BUILD_TYPE=Release
@@ -129,6 +129,8 @@ jobs:
   variables:
   - group: common
   - template: /.azuredevops/variables-global.yml
+  - name: ROCM_PATH
+    value: $(Agent.BuildDirectory)/rocm
   pool: $(JOB_TEST_POOL)
   workspace:
     clean: all


### PR DESCRIPTION
Sets `ROCM_PATH` env for MIOpen tests for https://github.com/ROCm/MIOpen/pull/3391
Change cmake flag from `AMDGPU_TARGETS` to `GPU_TARGETS`

Build log:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=20849&view=results