### PR TITLE
Ex CI: adjust MIOpen's CK fetch script to no longer find parent commits

### DIFF
--- a/.azuredevops/templates/steps/miopen-get-ck-build.yml
+++ b/.azuredevops/templates/steps/miopen-get-ck-build.yml
@@ -35,6 +35,8 @@ steps:
         CK_BUILD_ID=$(curl -s $LATEST_BUILD_URL | jq '.value[0].id')
         echo "Found latest CK build ID: $CK_BUILD_ID"
         EXIT_CODE=1
+      else
+        echo "Found specific CK build ID: $CK_BUILD_ID"
       fi
 
       AZURE_URL="$AZ_API/build/builds/$CK_BUILD_ID/artifacts?artifactName=$ARTIFACT_NAME&api-version=7.1"
@@ -42,17 +44,13 @@ steps:
 
       # If using the specific CK commit and it doesn't have any valid artifacts, use latest successful CK build instead
       if { [[ -z "$ARTIFACT_URL" ]] || [[ "$ARTIFACT_URL" == "null" ]]; } && [[ $EXIT_CODE -eq 0 ]]; then
-        echo "Did not find specific CK build artifact"
+        echo "Did not find valid specific CK build artifact"
         LATEST_BUILD_URL="$AZ_API/build/builds?definitions=$(COMPOSABLE_KERNEL_PIPELINE_ID)&statusFilter=completed&resultFilter=succeeded&\$top=1&api-version=7.1"
         CK_BUILD_ID=$(curl -s $LATEST_BUILD_URL | jq '.value[0].id')
         echo "Found latest CK build ID: $CK_BUILD_ID"
         AZURE_URL="$AZ_API/build/builds/$CK_BUILD_ID/artifacts?artifactName=$ARTIFACT_NAME&api-version=7.1"
         ARTIFACT_URL=$(curl -s $AZURE_URL | jq '.resource.downloadUrl' | tr -d '"')
         EXIT_CODE=2
-      fi
-
-      if [[ $EXIT_CODE -eq 0 ]]; then
-        echo "Found specific CK build ID: $CK_BUILD_ID"
       fi
 
       echo "Downloading CK artifact from $ARTIFACT_URL"
@@ -62,9 +60,13 @@ steps:
       tar -zxvf $(System.ArtifactsDirectory)/$ARTIFACT_NAME/*.tar.gz -C $(Agent.BuildDirectory)/rocm
       rm -r $(System.ArtifactsDirectory)/ck.zip $(System.ArtifactsDirectory)/$ARTIFACT_NAME
 
-      if [ $EXIT_CODE -ne 0 ]; then
+      if [[ $EXIT_CODE -ne 0 ]]; then
         BUILD_COMMIT=$(curl -s $AZ_API/build/builds/$CK_BUILD_ID | jq '.sourceVersion' | tr -d '"')
-        echo "WARNING: couldn't find a CK build for commit $CK_COMMIT"
+        if [[ $EXIT_CODE -eq 1 ]]; then
+          echo "WARNING: couldn't find a CK build for commit $CK_COMMIT"
+        elif [[ $EXIT_CODE -eq 2 ]]; then
+          echo "WARNING: couldn't find a valid CK artifact for commit $CK_COMMIT"
+        fi
         echo "Instead used latest CK build $CK_BUILD_ID for commit $BUILD_COMMIT"
       fi
       exit $EXIT_CODE

--- a/.azuredevops/templates/steps/miopen-get-ck-build.yml
+++ b/.azuredevops/templates/steps/miopen-get-ck-build.yml
@@ -20,7 +20,7 @@ steps:
       ARTIFACT_NAME="composablekernel.${{ parameters.gpuTarget }}"
       EXIT_CODE=0
 
-      # Try to find an Azure build for the CK commit called out in MIOpen's requirements.txt
+      # Try to find an Azure build for the specific CK commit called out in MIOpen's requirements.txt
       CK_COMMIT=$(grep 'ROCm/composable_kernel' requirements.txt | sed -E 's/.*@([a-f0-9]{40}).*/\1/')
       echo "Fetching CK build ID for commit $CK_COMMIT"
       CK_CHECKS_URL="$GH_API/composable_kernel/commits/${CK_COMMIT}/check-runs"
@@ -28,8 +28,8 @@ steps:
         jq '.check_runs[] | select(.name == "composable_kernel" and .app.slug == "azure-pipelines") | .details_url' | \
         tr -d '"' | grep -oP 'buildId=\K\d+')
 
-      # If none found, use the latest successful CK build instead
-      if [ -z "$CK_BUILD_ID" ]; then
+      # If none found, use latest successful CK build instead
+      if [[ -z "$CK_BUILD_ID" ]]; then
         echo "Did not find specific CK build ID"
         LATEST_BUILD_URL="$AZ_API/build/builds?definitions=$(COMPOSABLE_KERNEL_PIPELINE_ID)&statusFilter=completed&resultFilter=succeeded&\$top=1&api-version=7.1"
         CK_BUILD_ID=$(curl -s $LATEST_BUILD_URL | jq '.value[0].id')
@@ -39,6 +39,22 @@ steps:
 
       AZURE_URL="$AZ_API/build/builds/$CK_BUILD_ID/artifacts?artifactName=$ARTIFACT_NAME&api-version=7.1"
       ARTIFACT_URL=$(curl -s $AZURE_URL | jq '.resource.downloadUrl' | tr -d '"')
+
+      # If using the specific CK commit and it doesn't have any valid artifacts, use latest successful CK build instead
+      if [[ -z "$ARTIFACT_URL" ]] && [[ $EXIT_CODE -eq 0 ]]; then
+        echo "Did not find specific CK build artifact"
+        LATEST_BUILD_URL="$AZ_API/build/builds?definitions=$(COMPOSABLE_KERNEL_PIPELINE_ID)&statusFilter=completed&resultFilter=succeeded&\$top=1&api-version=7.1"
+        CK_BUILD_ID=$(curl -s $LATEST_BUILD_URL | jq '.value[0].id')
+        echo "Found latest CK build ID: $CK_BUILD_ID"
+        AZURE_URL="$AZ_API/build/builds/$CK_BUILD_ID/artifacts?artifactName=$ARTIFACT_NAME&api-version=7.1"
+        ARTIFACT_URL=$(curl -s $AZURE_URL | jq '.resource.downloadUrl' | tr -d '"')
+        EXIT_CODE=2
+      fi
+
+      if [[ $EXIT_CODE -eq 0 ]]; then
+        echo "Found specific CK build ID: $CK_BUILD_ID"
+      fi
+
       echo "Downloading CK artifact from $ARTIFACT_URL"
       wget -nv $ARTIFACT_URL -O $(System.ArtifactsDirectory)/ck.zip
       unzip $(System.ArtifactsDirectory)/ck.zip -d $(System.ArtifactsDirectory)

--- a/.azuredevops/templates/steps/miopen-get-ck-build.yml
+++ b/.azuredevops/templates/steps/miopen-get-ck-build.yml
@@ -20,20 +20,15 @@ steps:
       ARTIFACT_NAME="composablekernel.${{ parameters.gpuTarget }}"
       EXIT_CODE=0
 
-      # The commits that MIOpen reference are all merge commits from CK/develop to CK/amd-develop
-      # These commits are present on CK/amd-develop but not on CK/develop
-      # Ex-CI only builds CK/develop, so we need to find a commit present on both CK/develop and CK/amd-develop
-
+      # Try to find an Azure build for the CK commit called out in MIOpen's requirements.txt
       CK_COMMIT=$(grep 'ROCm/composable_kernel' requirements.txt | sed -E 's/.*@([a-f0-9]{40}).*/\1/')
       echo "Fetching CK build ID for commit $CK_COMMIT"
-      CK_COMMIT_URL="$GH_API/composable_kernel/commits/${CK_COMMIT}"
-      PARENT_COMMIT=$(curl -s $CK_COMMIT_URL | jq '.parents[1].sha' | tr -d '"')
-      echo "Found parent commit: $PARENT_COMMIT"
-      PARENT_CHECKS_URL="$GH_API/composable_kernel/commits/${PARENT_COMMIT}/check-runs"
-      CK_BUILD_ID=$(curl -s $PARENT_CHECKS_URL | \
+      CK_CHECKS_URL="$GH_API/composable_kernel/commits/${CK_COMMIT}/check-runs"
+      CK_BUILD_ID=$(curl -s $CK_CHECKS_URL | \
         jq '.check_runs[] | select(.name == "composable_kernel" and .app.slug == "azure-pipelines") | .details_url' | \
         tr -d '"' | grep -oP 'buildId=\K\d+')
 
+      # If none found, use the latest successful CK build instead
       if [ -z "$CK_BUILD_ID" ]; then
         echo "Did not find specific CK build ID"
         LATEST_BUILD_URL="$AZ_API/build/builds?definitions=$(COMPOSABLE_KERNEL_PIPELINE_ID)&statusFilter=completed&resultFilter=succeeded&\$top=1&api-version=7.1"
@@ -44,19 +39,6 @@ steps:
 
       AZURE_URL="$AZ_API/build/builds/$CK_BUILD_ID/artifacts?artifactName=$ARTIFACT_NAME&api-version=7.1"
       ARTIFACT_URL=$(curl -s $AZURE_URL | jq '.resource.downloadUrl' | tr -d '"')
-
-      if [ -z "$ARTIFACT_URL" ]; then
-        echo "Did not find specific CK build artifact"
-        LATEST_BUILD_URL="$AZ_API/build/builds?definitions=$(COMPOSABLE_KERNEL_PIPELINE_ID)&status=completed&result=succeeded&\$top=1&api-version=7.1"
-        CK_BUILD_ID=$(curl -s $LATEST_BUILD_URL | jq '.value[0].id')
-        echo "Found latest CK build ID: $CK_BUILD_ID"
-        AZURE_URL="$AZ_API/build/builds/$CK_BUILD_ID/artifacts?artifactName=$ARTIFACT_NAME&api-version=7.1"
-        ARTIFACT_URL=$(curl -s $AZURE_URL | jq '.resource.downloadUrl' | tr -d '"')
-        EXIT_CODE=2
-      elif [ $EXIT_CODE -eq 0 ]; then
-        echo "Found specific CK build ID: $CK_BUILD_ID"
-      fi
-
       echo "Downloading CK artifact from $ARTIFACT_URL"
       wget -nv $ARTIFACT_URL -O $(System.ArtifactsDirectory)/ck.zip
       unzip $(System.ArtifactsDirectory)/ck.zip -d $(System.ArtifactsDirectory)

--- a/.azuredevops/templates/steps/miopen-get-ck-build.yml
+++ b/.azuredevops/templates/steps/miopen-get-ck-build.yml
@@ -41,7 +41,7 @@ steps:
       ARTIFACT_URL=$(curl -s $AZURE_URL | jq '.resource.downloadUrl' | tr -d '"')
 
       # If using the specific CK commit and it doesn't have any valid artifacts, use latest successful CK build instead
-      if [[ -z "$ARTIFACT_URL" ]] && [[ $EXIT_CODE -eq 0 ]]; then
+      if { [[ -z "$ARTIFACT_URL" ]] || [[ "$ARTIFACT_URL" == "null" ]]; } && [[ $EXIT_CODE -eq 0 ]]; then
         echo "Did not find specific CK build artifact"
         LATEST_BUILD_URL="$AZ_API/build/builds?definitions=$(COMPOSABLE_KERNEL_PIPELINE_ID)&statusFilter=completed&resultFilter=succeeded&\$top=1&api-version=7.1"
         CK_BUILD_ID=$(curl -s $LATEST_BUILD_URL | jq '.value[0].id')


### PR DESCRIPTION
The CK promotion process changed slightly, and the previous method of finding parent commits no longer works for MIOpen. Since CI is now enabled for CK's amd-develop branch (https://github.com/ROCm/composable_kernel/pull/1859), we can directly search for the commit called out in [requirements.txt](https://github.com/ROCm/MIOpen/blob/develop/requirements.txt)

If no valid build or artifact is found, it will continue to fall back to the latest successful CK build.

Sample run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=20948&view=logs&j=832f3a36-34cd-5de6-6cd3-6744a08875be&t=cf727a4d-891e-5a95-0f3a-52baaaad2efb

[A compiler build fix](https://github.com/ROCm/composable_kernel/commit/78195cccad673825f046523e84c503de7e741ef1) has not been promoted to amd-develop yet, so the result of not finding a valid artifact is correct.