### PR TITLE
Ex CI: add rocm-cmake to rpp build job

### DIFF
--- a/.azuredevops/components/rpp.yml
+++ b/.azuredevops/components/rpp.yml
@@ -29,6 +29,7 @@ parameters:
     - clr
     - half
     - llvm-project
+    - rocm-cmake
     - rocminfo
     - ROCR-Runtime
 - name: rocmTestDependencies

--- a/.azuredevops/components/rpp.yml
+++ b/.azuredevops/components/rpp.yml
@@ -80,6 +80,7 @@ jobs:
         -DHALF_INCLUDE_DIRS=$(Agent.BuildDirectory)/rocm/include
         -DCMAKE_BUILD_TYPE=Release
         -DGPU_TARGETS=$(JOB_GPU_TARGET)
+        -DROCM_PLATFORM_VERSION=$(NEXT_RELEASE_VERSION)
         -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
     parameters:


### PR DESCRIPTION
Adds rocm-cmake as a build dep for https://github.com/ROCm/rpp/pull/516

A longer-term fix for the manual `ROCM_PLATFORM_VERSION` flag setting is being worked on [in this branch](https://github.com/ROCm/ROCm/tree/amd/danielsu/rocm-cmake-ROCM_PLATFORM_PATH)

Sample run (build job passed, pending test job results):
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=20987&view=results