### PR TITLE
Ex CI: change rocprof-compute default branch to develop

### DIFF
--- a/.azuredevops/components/rocm_smi_lib.yml
+++ b/.azuredevops/components/rocm_smi_lib.yml
@@ -10,6 +10,7 @@ parameters:
   default:
     - cmake
     - libdrm-dev
+    - pkg-config
     - python3-pip
 
 jobs:

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -262,7 +262,7 @@ parameters:
       hasGpuTarget: true
     rocprofiler-compute:
       pipelineId: $(ROCPROFILER_COMPUTE_PIPELINE_ID)
-      stagingBranch: amd-staging
+      stagingBranch: develop
       mainlineBranch: amd-mainline
       hasGpuTarget: true
     rocprofiler-register:


### PR DESCRIPTION
[rocprofiler-compute](https://github.com/ROCm/rocprofiler-compute)'s default branch has changed to `develop`.

Also adds pkg-config to rocm_smi_lib to fix a build error:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=21365&view=results