### PR TITLE
Ex CI: update to 6.3.3

### DIFF
--- a/.azuredevops/variables-global.yml
+++ b/.azuredevops/variables-global.yml
@@ -28,13 +28,13 @@ variables:
 - name: GFX942_TEST_POOL
   value: gfx942_test_pool
 - name: LATEST_RELEASE_VERSION
-  value: 6.3.2
+  value: 6.3.3
 - name: REPO_RADEON_VERSION
-  value: 6.3.2
+  value: 6.3.3
 - name: NEXT_RELEASE_VERSION
   value: 6.4.0
 - name: LATEST_RELEASE_TAG
-  value: rocm-6.3.2
+  value: rocm-6.3.3
 - name: AMDMIGRAPHX_GFX942_TEST_PIPELINE_ID
   value: 197
 - name: AMDMIGRAPHX_PIPELINE_ID


### PR DESCRIPTION
Update to ROCm 6.3.3

Sample build w/ repo registration and aqlprofile dependency:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=21367&view=results