### PR TITLE
Ex CI: fix rocm-cmake tests, update component branch names

### DIFF
--- a/.azuredevops/components/rocm-cmake.yml
+++ b/.azuredevops/components/rocm-cmake.yml
@@ -19,6 +19,7 @@ parameters:
   default:
     - cget
     - ninja
+    - rocm-docs-core
 
 jobs:
 - job: rocm_cmake

--- a/.azuredevops/components/rocm-cmake.yml
+++ b/.azuredevops/components/rocm-cmake.yml
@@ -17,7 +17,7 @@ parameters:
   type: object
   default:
     - cget
-    - cmake==3.20.6
+    - cmake==3.20.5
     - ninja
     - rocm-docs-core
 

--- a/.azuredevops/components/rocm-cmake.yml
+++ b/.azuredevops/components/rocm-cmake.yml
@@ -34,18 +34,25 @@ jobs:
     parameters:
       aptPackages: ${{ parameters.aptPackages }}
       pipModules: ${{ parameters.pipModules }}
+  - task: Bash@3
+    displayName: Add CMake to PATH
+    inputs:
+      targetType: inline
+      script: echo "##vso[task.prependpath]$(python3 -m site --user-base)/bin"
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
     parameters:
       checkoutRepo: ${{ parameters.checkoutRepo }}
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
-# extra steps for ctest suite
-  - script: |
-      python -m pip install -r $(Build.SourcesDirectory)/docs/requirements.txt
-      python -m pip install -r $(Build.SourcesDirectory)/test/docsphinx/docs/.sphinx/requirements.txt
-      git config --global user.email "you@example.com"
-      git config --global user.name "Your Name"
-    displayName: "ctest setup"
+  - task: Bash@3
+    displayName: CTest setup
+    inputs:
+      targetType: inline
+      script: |
+        python -m pip install -r $(Build.SourcesDirectory)/docs/requirements.txt
+        python -m pip install -r $(Build.SourcesDirectory)/test/docsphinx/docs/.sphinx/requirements.txt
+        git config --global user.email "you@example.com"
+        git config --global user.name "Your Name"
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
     parameters:
       componentName: rocm-cmake

--- a/.azuredevops/components/rocm-cmake.yml
+++ b/.azuredevops/components/rocm-cmake.yml
@@ -8,7 +8,6 @@ parameters:
 - name: aptPackages
   type: object
   default:
-    - cmake
     - doxygen
     - doxygen-doc
     - ninja-build
@@ -18,6 +17,7 @@ parameters:
   type: object
   default:
     - cget
+    - cmake==3.20.6
     - ninja
     - rocm-docs-core
 
@@ -49,6 +49,7 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
     parameters:
       componentName: rocm-cmake
+      testParameters: '-E "pass-version-parent" -VV --output-on-failure --force-new-ctest-process --output-junit test_output.xml'
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -222,13 +222,13 @@ parameters:
       hasGpuTarget: false
     rocm-examples:
       pipelineId: $(ROCM_EXAMPLES_PIPELINE_ID)
-      stagingBranch: develop
-      mainlineBranch: develop
+      stagingBranch: amd-staging
+      mainlineBranch: amd-mainline
       hasGpuTarget: true
     rocminfo:
       pipelineId: $(ROCMINFO_PIPELINE_ID)
       stagingBranch: amd-staging
-      mainlineBranch: amd-master
+      mainlineBranch: amd-mainline
       hasGpuTarget: false
     rocMLIR:
       pipelineId: $(ROCMLIR_PIPELINE_ID)

--- a/.azuredevops/templates/steps/test.yml
+++ b/.azuredevops/templates/steps/test.yml
@@ -33,7 +33,6 @@ parameters:
     - aomp
     - HIPIFY
     - MIVisionX
-    - rocm-cmake
     - rocm_smi_lib
     - rocprofiler-sdk
     - roctracer


### PR DESCRIPTION
Updates branch names for rocminfo and rocm-examples.

Fixes all rocm-cmake tests to now pass, removed it from the list of allowed failures.
- Downgrade to cmake 3.20.5 to fix simple-test
- Skip version-parent as it expects to be run in a git repo, which is not the case here

Build log: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=22194&view=logs&j=65d9a8c4-c7f3-5147-6903-54915f681079&t=399c18ed-247c-533c-c28a-e58e44181d65