### PR TITLE
Ex CI: increase hipBLASLt test timeout to 2 hours

### DIFF
--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -158,6 +158,7 @@ jobs:
         - deps
 
 - job: hipBLASLt_testing
+  timeoutInMinutes: 120
   dependsOn: hipBLASLt
   condition: and(succeeded(), eq(variables.ENABLE_GFX942_TESTS, 'true'), not(containsValue(split(variables.DISABLED_GFX942_TESTS, ','), variables['Build.DefinitionName'])))
   variables:


### PR DESCRIPTION
To resolve hipBLASLt tests exceeding one hour and timing out.