### PR TITLE
Ex CI: update to 6.3.4, fixes for rocm-smi and rocWMMA

### DIFF
--- a/.azuredevops/components/rocWMMA.yml
+++ b/.azuredevops/components/rocWMMA.yml
@@ -98,7 +98,7 @@ jobs:
       gpuTarget: $(JOB_GPU_TARGET)
 
 - job: rocWMMA_testing
-  timeoutInMinutes: 90
+  timeoutInMinutes: 120
   dependsOn: rocWMMA
   condition: and(succeeded(), eq(variables.ENABLE_GFX942_TESTS, 'true'), not(containsValue(split(variables.DISABLED_GFX942_TESTS, ','), variables['Build.DefinitionName'])))
   variables:

--- a/.azuredevops/components/rocm_smi_lib.yml
+++ b/.azuredevops/components/rocm_smi_lib.yml
@@ -56,6 +56,9 @@ jobs:
         JOB_GPU_TARGET: gfx942
         JOB_TEST_POOL: ${{ variables.GFX942_TEST_POOL }}
   steps:
+  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
+    parameters:
+      aptPackages: ${{ parameters.aptPackages }}
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml

--- a/.azuredevops/variables-global.yml
+++ b/.azuredevops/variables-global.yml
@@ -28,13 +28,13 @@ variables:
 - name: GFX942_TEST_POOL
   value: gfx942_test_pool
 - name: LATEST_RELEASE_VERSION
-  value: 6.3.3
+  value: 6.3.4
 - name: REPO_RADEON_VERSION
-  value: 6.3.3
+  value: 6.3.4
 - name: NEXT_RELEASE_VERSION
   value: 6.4.0
 - name: LATEST_RELEASE_TAG
-  value: rocm-6.3.3
+  value: rocm-6.3.4
 - name: AMDMIGRAPHX_GFX942_TEST_PIPELINE_ID
   value: 197
 - name: AMDMIGRAPHX_PIPELINE_ID


### PR DESCRIPTION
- Updates to ROCm 6.3.4
- Add a missing apt packages step for rocm-smi tests
- Extend rocWMMA test time limit to 2 hours

rocm-smi build:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=22695&view=results