### PR TITLE
Ex CI: fixes for rocMLIR, rocPyDecode, RVS, rocprof-compute

### DIFF
--- a/.azuredevops/components/ROCmValidationSuite.yml
+++ b/.azuredevops/components/ROCmValidationSuite.yml
@@ -120,9 +120,11 @@ jobs:
       gfx942:
         JOB_GPU_TARGET: gfx942
         JOB_TEST_POOL: ${{ variables.GFX942_TEST_POOL }}
+        TEST_CONF_DIR: MI300X
       gfx90a:
         JOB_GPU_TARGET: gfx90a
         JOB_TEST_POOL: ${{ variables.GFX90A_TEST_POOL }}
+        TEST_CONF_DIR: MI210
   steps:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
     parameters:
@@ -141,7 +143,7 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
     parameters:
       componentName: ROCmValidationSuite
-      testExecutable: $(Agent.BuildDirectory)/rocm/bin/rvs -c $(Agent.BuildDirectory)/rocm/share/rocm-validation-suite/conf/MI300X/gst_single.conf
+      testExecutable: $(Agent.BuildDirectory)/rocm/bin/rvs -c $(Agent.BuildDirectory)/rocm/share/rocm-validation-suite/conf/$(TEST_CONF_DIR)/gst_single.conf
       testParameters: ''
       testDir: $(Agent.BuildDirectory)
       testPublishResults: false

--- a/.azuredevops/components/rocMLIR.yml
+++ b/.azuredevops/components/rocMLIR.yml
@@ -21,7 +21,7 @@ parameters:
     - numpy
     - ml_dtypes
     - scipy
-    - hip-python --index-url https://test.pypi/org/simple
+    - hip-python --extra-index-url https://test.pypi/org/simple
 - name: rocmDependencies
   type: object
   default:

--- a/.azuredevops/components/rocMLIR.yml
+++ b/.azuredevops/components/rocMLIR.yml
@@ -18,6 +18,10 @@ parameters:
   type: object
   default:
     - tomli
+    - numpy
+    - ml_dtypes
+    - scipy
+    - hip-python --index-url https://test.pypi/org/simple
 - name: rocmDependencies
   type: object
   default:

--- a/.azuredevops/components/rocMLIR.yml
+++ b/.azuredevops/components/rocMLIR.yml
@@ -21,7 +21,7 @@ parameters:
     - numpy
     - ml_dtypes
     - scipy
-    - hip-python --extra-index-url https://test.pypi/org/simple
+    - hip-python --extra-index-url https://test.pypi.org/simple
 - name: rocmDependencies
   type: object
   default:

--- a/.azuredevops/components/rocMLIR.yml
+++ b/.azuredevops/components/rocMLIR.yml
@@ -9,19 +9,19 @@ parameters:
   type: object
   default:
     - cmake
-    - ninja-build
     - git
-    - python3-pip
     - libdrm-dev
     - libstdc++-12-dev
+    - ninja-build
+    - python3-pip
 - name: pipModules
   type: object
   default:
-    - tomli
-    - numpy
-    - ml_dtypes
-    - scipy
     - hip-python --extra-index-url https://test.pypi.org/simple
+    - ml_dtypes
+    - numpy
+    - tomli
+    - scipy
 - name: rocmDependencies
   type: object
   default:

--- a/.azuredevops/components/rocPyDecode.yml
+++ b/.azuredevops/components/rocPyDecode.yml
@@ -22,19 +22,20 @@ parameters:
 - name: pipModules
   type: object
   default:
+    - hip-python --extra-index-url https://test.pypi.org/simple
     - numpy
     - pybind11
 - name: rocmDependencies
   type: object
   default:
-    - rocm-cmake
-    - llvm-project
-    - ROCR-Runtime
     - clr
-    - rocminfo
-    - rocm-core
-    - rocprofiler-register
+    - llvm-project
     - rocDecode
+    - rocm-cmake
+    - rocm-core
+    - rocminfo
+    - ROCR-Runtime
+    - rocprofiler-register
 
 jobs:
 - job: rocPyDecode
@@ -55,11 +56,6 @@ jobs:
     parameters:
       aptPackages: ${{ parameters.aptPackages }}
       pipModules: ${{ parameters.pipModules }}
-  - task: Bash@3
-    displayName: 'pip install hip-python'
-    inputs:
-      targetType: inline
-      script: pip install -i https://test.pypi.org/simple hip-python
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
     parameters:
@@ -183,11 +179,6 @@ jobs:
     parameters:
       aptPackages: ${{ parameters.aptPackages }}
       pipModules: ${{ parameters.pipModules }}
-  - task: Bash@3
-    displayName: 'pip install hip-python'
-    inputs:
-      targetType: inline
-      script: pip install -i https://test.pypi.org/simple hip-python
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
   - task: DownloadPipelineArtifact@2
     displayName: 'Download Pipeline Wheel Files'

--- a/.azuredevops/components/rocprofiler-compute.yml
+++ b/.azuredevops/components/rocprofiler-compute.yml
@@ -160,7 +160,7 @@ jobs:
     parameters:
       componentName: rocprofiler-compute
       testDir: $(Build.BinariesDirectory)/libexec/rocprofiler-compute
-      testExecutable: ROCPROFCOMPUTE_ARCH_OVERRIDE="MI300X" ROCM_PATH=$(Agent.BuildDirectory)/rocm ctest
+      testExecutable: ROCM_PATH=$(Agent.BuildDirectory)/rocm ctest
   - task: Bash@3
     displayName: Remove ROCm binaries from PATH
     condition: always()


### PR DESCRIPTION
- rocMLIR
  - Install hip-python pip package, other python deps
  - For https://github.com/ROCm/rocMLIR/pull/1762
- rocPyDecode
  - Change hip-python installation method to match rocMLIR
- ROCmValidationSuite
  - Matrix-ize the test conf file directory to not be hardcoded for MI300X
  - Sample run: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=22884&view=results
    - Run is based off https://github.com/ROCm/ROCmValidationSuite/pull/908 since it contains a critical build fix
- rocprofiler-compute
  - Removed a long-deprecated `ROCPROFCOMPUTE_ARCH_OVERRIDE` var that was being set for tests