### PR TITLE
Fix "VGPR" typo in workload tuning guide

### DIFF
--- a/docs/how-to/rocm-for-ai/inference-optimization/workload.rst
+++ b/docs/how-to/rocm-for-ai/inference-optimization/workload.rst
@@ -1705,12 +1705,12 @@ efficiency and throughput of various computational kernels.
 
    Occupancy related to VGPRs usage on an Instinct MI300X accelerator
 
-For example, according to the table, the available VGPR is 512 per Execution
-Unit (EU), and VGPR is allocated at the unit of 16. If the current VGPR usage
-is 170, the actual requested VGPR will be 176, so the occupancy is only 2
-waves per EU since :math:`176 \times 3 > 512`. So, if you set
-``waves_per_eu`` to 3, the LLVM backend tries to bring VGPR usage down so
-that it might fit 3 waves per EU.
+For example, according to the table, each Execution Unit (EU) has 512 available
+VGPRs, which are allocated in blocks of 16. If the current VGPR usage is 170,
+it will be rounded up to 176 due to the allocation granularity. In this case,
+the occupancy is limited to 2 waves per EU because :math:`176 \times 3 > 512`.
+So, if you set ``waves_per_eu`` to 3, the LLVM backend will attempt to reduce
+VGPR usage so that it might fit 3 waves per EU.
 
 ``BLOCK_M``, ``BLOCK_N``, ``BLOCK_K``
    Tile sizes to be tuned to balance the memory-to-computation ratio. The goal

--- a/docs/how-to/rocm-for-ai/inference-optimization/workload.rst
+++ b/docs/how-to/rocm-for-ai/inference-optimization/workload.rst
@@ -1706,7 +1706,7 @@ efficiency and throughput of various computational kernels.
    Occupancy related to VGPRs usage on an Instinct MI300X accelerator
 
 For example, according to the table, the available VGPR is 512 per Execution
-Unit (EU), and VGPU is allocated at the unit of 16. If the current VGPR usage
+Unit (EU), and VGPR is allocated at the unit of 16. If the current VGPR usage
 is 170, the actual requested VGPR will be 176, so the occupancy is only 2
 waves per EU since :math:`176 \times 3 > 512`. So, if you set
 ``waves_per_eu`` to 3, the LLVM backend tries to bring VGPR usage down so


### PR DESCRIPTION
"VGPU" should be VGPR.