### PR TITLE
Ex CI: fixes for RDC, rocprof-sdk, hipBLASLt, CK

### DIFF
--- a/.azuredevops/components/composable_kernel.yml
+++ b/.azuredevops/components/composable_kernel.yml
@@ -103,7 +103,7 @@ jobs:
       gpuTarget: $(JOB_GPU_TARGET)
 
 - job: composable_kernel_testing
-  timeoutInMinutes: 90
+  timeoutInMinutes: 180
   dependsOn: composable_kernel
   condition: and(succeeded(), eq(variables.ENABLE_GFX942_TESTS, 'true'), not(containsValue(split(variables.DISABLED_GFX942_TESTS, ','), variables['Build.DefinitionName'])))
   variables:

--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -158,7 +158,7 @@ jobs:
         - deps
 
 - job: hipBLASLt_testing
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   dependsOn: hipBLASLt
   condition: and(succeeded(), eq(variables.ENABLE_GFX942_TESTS, 'true'), not(containsValue(split(variables.DISABLED_GFX942_TESTS, ','), variables['Build.DefinitionName'])))
   variables:

--- a/.azuredevops/components/rdc.yml
+++ b/.azuredevops/components/rdc.yml
@@ -85,7 +85,7 @@ jobs:
     displayName: 'git clone grpc'
     inputs:
       targetType: inline
-      script: git clone -b v1.61.0 https://github.com/grpc/grpc --depth=1 --shallow-submodules --recurse-submodules
+      script: git clone -b v1.67.1 https://github.com/grpc/grpc --depth=1 --shallow-submodules --recurse-submodules
       workingDirectory: $(Build.SourcesDirectory)
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
     parameters:

--- a/.azuredevops/components/rocprofiler-sdk.yml
+++ b/.azuredevops/components/rocprofiler-sdk.yml
@@ -13,6 +13,7 @@ parameters:
     - libdrm-dev
     - libdw-dev
     - libelf-dev
+    - libva-dev
     - pkg-config
     - python3-pip
 - name: pipModules
@@ -44,6 +45,7 @@ parameters:
     - rocminfo
     - ROCR-Runtime
     - rocprofiler-register
+    - roctracer
 
 jobs:
 - job: rocprofiler_sdk
@@ -140,12 +142,13 @@ jobs:
       dependencyList: ${{ parameters.rocmDependencies }}
       gpuTarget: $(JOB_GPU_TARGET)
   - task: Bash@3
-    displayName: Add Python site-packages binaries to path
+    displayName: Add Python and ROCm binaries to path
     inputs:
       targetType: inline
       script: |
         USER_BASE=$(python3 -m site --user-base)
         echo "##vso[task.prependpath]$USER_BASE/bin"
+        echo "##vso[task.prependpath]$(Agent.BuildDirectory)/rocm/bin"
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
     parameters:
       extraBuildFlags: >-
@@ -155,6 +158,7 @@ jobs:
         -DROCPROFILER_BUILD_RELEASE=ON
         -DGPU_TARGETS=$(JOB_GPU_TARGET)
       multithreadFlag: -- -j16
+  - template: ${{ variables.CI_TEMPLATE_PATH}}/steps/gpu-diagnostics.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
     parameters:
       componentName: rocprofiler-sdk


### PR DESCRIPTION
- RDC
  - Updated gRPC to 1.67.1
 https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=23353&view=results
- hipBLASLt
  - Increased test timeout to 3 hours
- rocprof-sdk
  - Added roctracer and libva-dev
  - Added rocminfo to PATH
  - Added GPU diags step before tests
 https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=23354&view=results
- composable_kernel
  - Increased test timeout to 3 hours