### PR TITLE
Ex CI: add gfx90a to nightly job

### DIFF
--- a/.azuredevops/ci-builds/aomp-mainline.yml
+++ b/.azuredevops/ci-builds/aomp-mainline.yml
@@ -8,29 +8,29 @@ resources:
     type: github
     endpoint: ROCm
     name: ROCm/aomp
-    ref: amd-mainline-open
+    ref: amd-mainline
   - repository: aomp-extras_repo
     type: github
     endpoint: ROCm
     name: ROCm/aomp-extras
-    ref: amd-mainline-open
+    ref: amd-mainline
   - repository: flang_repo
     type: github
     endpoint: ROCm
     name: ROCm/flang
-    ref: amd-mainline-open
+    ref: amd-mainline
   - repository: llvm-project_repo
     type: github
     endpoint: ROCm
     name: ROCm/llvm-project
-    ref: amd-mainline-open
+    ref: amd-mainline
   pipelines:
   - pipeline: rocr-runtime_pipeline
     source: \ROCR-Runtime
     trigger:
       branches:
         include:
-        - amd-master
+        - amd-mainline
 # this job will only be triggered after successful build sequence of llvm-project and ROCR-Runtime
 
 trigger: none

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -1,10 +1,14 @@
 parameters:
-- name: dependencySource
-  type: string
-  default: staging
-  values: 
-    - staging
-    - mainline
+# using a parameter instead of a strategy matrix allows job variables to be eval'd at compile-time rather than runtime
+- name: jobList
+  type: object
+  default:
+    - gfx942-staging:
+      target: gfx942
+      source: staging
+    - gfx90a-staging:
+      target: gfx90a
+      source: staging
 - name: rocmDependencies
   type: object
   default:
@@ -78,62 +82,59 @@ schedules:
   always: true
 
 jobs:
-- job: rocm_nightly
-  variables:
-  - group: common
-  - template: /.azuredevops/variables-global.yml
-  pool: ${{ variables.MEDIUM_BUILD_POOL }}
-  workspace:
-    clean: all
-  strategy:
-    matrix:
-      gfx942:
-        JOB_GPU_TARGET: gfx942
-  steps:
-  - task: DeleteFiles@1
-    displayName: 'Cleanup checkout space'
-    inputs:
-      SourceFolder: '$(Agent.BuildDirectory)/s'
-      Contents: '**/*'
-  - task: DeleteFiles@1
-    displayName: 'Cleanup Staging Area'
-    inputs:
-      SourceFolder: '$(Build.ArtifactStagingDirectory)'
-      Contents: '/**/*'
-      RemoveDotFiles: true
-  - script: df -h
-    displayName: System disk space before ROCm
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
-    parameters:
-      dependencySource: ${{ parameters.dependencySource }}
-      dependencyList: ${{ parameters.rocmDependencies }}
-      gpuTarget: $(JOB_GPU_TARGET)
-      skipLibraryLinking: true
-      skipLlvmSymlink: true
-  - script: df -h
-    displayName: System disk space after ROCm
-  - script: du -sh $(Agent.BuildDirectory)/rocm
-    displayName: Uncompressed ROCm size
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
-  - task: ArchiveFiles@2
-    displayName: Compress rocm-nightly
-    inputs:
-      rootFolderOrFile: $(Agent.BuildDirectory)/rocm
-      includeRootFolder: false
-      archiveType: tar
-      tarCompression: gz
-      archiveFile: $(Build.ArtifactStagingDirectory)/$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_$(JOB_GPU_TARGET).tar.gz
-  - script: du -sh $(Build.ArtifactStagingDirectory)
-    displayName: Compressed ROCm size
-  - task: PublishPipelineArtifact@1
-    displayName: 'Publish ROCm Nightly Artifact'
-    retryCountOnTaskFailure: 3
-    inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)'
-  - task: Bash@3
-    displayName: Save pipeline artifact file name
-    inputs:
-      workingDirectory: $(Pipeline.Workspace)
-      targetType: inline
-      script: echo "$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_$(JOB_GPU_TARGET).tar.gz" >> pipelineArtifacts.txt
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
+- ${{ each job in parameters.jobList }}:
+  - job: rocm_nightly_${{ job.target }}_${{ job.source }}
+    variables:
+    - group: common
+    - template: /.azuredevops/variables-global.yml
+    pool: ${{ variables.MEDIUM_BUILD_POOL }}
+    workspace:
+      clean: all
+    steps:
+    - task: DeleteFiles@1
+      displayName: 'Cleanup checkout space'
+      inputs:
+        SourceFolder: '$(Agent.BuildDirectory)/s'
+        Contents: '**/*'
+    - task: DeleteFiles@1
+      displayName: 'Cleanup Staging Area'
+      inputs:
+        SourceFolder: '$(Build.ArtifactStagingDirectory)'
+        Contents: '/**/*'
+        RemoveDotFiles: true
+    - script: df -h
+      displayName: System disk space before ROCm
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
+      parameters:
+        dependencySource: ${{ job.source }}
+        dependencyList: ${{ parameters.rocmDependencies }}
+        gpuTarget: ${{ job.target }}
+        skipLibraryLinking: true
+        skipLlvmSymlink: true
+    - script: df -h
+      displayName: System disk space after ROCm
+    - script: du -sh $(Agent.BuildDirectory)/rocm
+      displayName: Uncompressed ROCm size
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
+    - task: ArchiveFiles@2
+      displayName: Compress rocm-nightly
+      inputs:
+        rootFolderOrFile: $(Agent.BuildDirectory)/rocm
+        includeRootFolder: false
+        archiveType: tar
+        tarCompression: gz
+        archiveFile: $(Build.ArtifactStagingDirectory)/$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_${{ job.target }}.tar.gz
+    - script: du -sh $(Build.ArtifactStagingDirectory)
+      displayName: Compressed ROCm size
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish ROCm Nightly Artifact'
+      retryCountOnTaskFailure: 3
+      inputs:
+        targetPath: '$(Build.ArtifactStagingDirectory)'
+    - task: Bash@3
+      displayName: Save pipeline artifact file name
+      inputs:
+        workingDirectory: $(Pipeline.Workspace)
+        targetType: inline
+        script: echo "$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_${{ job.target }}.tar.gz" >> pipelineArtifacts.txt
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml

--- a/.azuredevops/templates/steps/artifact-download.yml
+++ b/.azuredevops/templates/steps/artifact-download.yml
@@ -32,7 +32,8 @@ steps:
     definition: ${{ parameters.pipelineId }}
     specificBuildWithTriggering: true
     itemPattern: '**/*${{ parameters.fileFilter }}*'
-    ${{ if notIn(parameters.componentName, 'aomp') }}: # remove this once these pipelines are functional + up-to-date
+    # aomp is a special case, since the trigger file is under ROCm/ROCm instead of the component repo
+    ${{ if notIn(parameters.componentName, 'aomp') }}:
       buildVersionToDownload: latestFromBranch # default is 'latest'
     branchName: refs/heads/${{ parameters.branchName }}
     allowPartiallySucceededBuilds: $(allowPartiallySucceededBuilds)

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -38,7 +38,7 @@ parameters:
     AMDMIGraphX:
       pipelineId: $(AMDMIGRAPHX_PIPELINE_ID)
       stagingBranch: develop
-      mainlineBranch: mainline
+      mainlineBranch: master
       hasGpuTarget: true
     amdsmi:
       pipelineId: $(AMDSMI_PIPELINE_ID)
@@ -53,7 +53,7 @@ parameters:
     aomp:
       pipelineId: $(AOMP_PIPELINE_ID)
       stagingBranch: aomp-dev
-      mainlineBranch: amd-mainline-open
+      mainlineBranch: amd-mainline
       hasGpuTarget: false
     clr:
       pipelineId: $(CLR_PIPELINE_ID)


### PR DESCRIPTION
- Added staging gfx90a builds to the nightly tarball
- Added support for mainline nightly tarballs, though that's not yet enabled since many components aren't set up for mainline yet
- Changed AMDMIGraphX and aomp mainline branch names
  - AMDMIGraphX
    - `mainline` -> `master`
  - aomp
    - `amd-mainline-open` -> `amd-mainline`
- Changed relevant resource and trigger branch names in `aomp-mainline.yml`
