### PR TITLE
[docs/7.13.0] Fix staging link in transition guide

### DIFF
--- a/docs/about/transition-guide-TheRock.md
+++ b/docs/about/transition-guide-TheRock.md
@@ -1,6 +1,6 @@
 # Transition guide from legacy ROCm release stream
 
-[ROCm Core SDK 7.13.0](https://rocm-stg.amd.com/en/docs-7.13.0/index.html#rocm-core-sdk) marks a step change from the ROCm legacy release stream. It is a preview release built on our new build system, TheRock.
+[ROCm Core SDK 7.13.0](https://rocm.docs.amd.com/en/7.13.0-preview/index.html#rocm-core-sdk) marks a step change from the ROCm legacy release stream. It is a preview release built on our new build system, TheRock.
 
 ## Major changes
 

--- a/docs/ai-inference/vllm.rst
+++ b/docs/ai-inference/vllm.rst
@@ -262,7 +262,7 @@ Prerequisites
       - Ensure your system has the AMD GPU Driver (amdgpu) installed. See the
         :ref:`compat-matrix` for driver support information. For installation
         instructions, see the `AMD GPU Driver documentation
-        <https://instinct.docs.amd.com/projects/amdgpu-docs/en/31.30.0-preview/install/detailed-install/package-manager/package-manager-index.html>`__.
+        <https://instinct.docs.amd.com/projects/amdgpu-docs/en/31.30.0-preview/index.html>`__.
 
       - Ensure the host system has `Docker Engine
         <https://docs.docker.com/engine/install/>`__ and the AMD GPU Driver
@@ -280,7 +280,7 @@ Prerequisites
       - Ensure your system has the AMD GPU Driver (amdgpu) installed. See the
         :ref:`compat-matrix` for driver support information. For installation
         instructions, see the `AMD GPU Driver documentation
-        <https://instinct.docs.amd.com/projects/amdgpu-docs/en/31.30.0-preview/install/detailed-install/package-manager/package-manager-index.html>`__.
+        <https://instinct.docs.amd.com/projects/amdgpu-docs/en/31.30.0-preview/index.html>`__.
 
    - Ensure your system has :ref:`Python 3.13 <rocm-compat-python>` installed and
      accessible. Review the :ref:`compat-matrix` for more support details.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -142,8 +142,8 @@ html_theme_options = {
     "announcement": f"This is ROCm {ROCM_VERSION} technology preview release documentation. For the latest production stream release, refer to <a id='rocm-banner' href='https://rocm.docs.amd.com/en/latest/'>ROCm documentation</a>.",
     "flavor": "generic",
     "header_title": f"ROCm™ {ROCM_VERSION} Preview",
-    "header_link": f"https://rocm-stg.amd.com/en/docs-7.13.0/index.html",
-    "version_list_link": f"https://rocm-stg.amd.com/en/docs-7.13.0/release/versions.html",
+    "header_link": f"https://rocm.docs.amd.com/en/7.13.0-preview/index.html",
+    "version_list_link": f"https://rocm.docs.amd.com/en/7.13.0-preview/release/versions.html",
     "nav_secondary_items": {
         "GitHub": "https://github.com/ROCm/ROCm",
         "Community": "https://github.com/ROCm/ROCm/discussions",

--- a/docs/data/landing-page/rocm-sdk-arch.html
+++ b/docs/data/landing-page/rocm-sdk-arch.html
@@ -13,7 +13,7 @@
             <div
               class="rocm-docs-core-sdk-tile bg-amd-blue p-2 h-100 d-flex align-items-center small fw-bold"
             >
-              <a href="./components/math-and-compute-libs.html" target="_blank">Math and compute libraries</a>
+              Math and compute libraries
             </div>
           </div>
           <div class="col-8">
@@ -72,7 +72,7 @@
             <div
               class="rocm-docs-core-sdk-tile bg-amd-blue p-2 h-100 d-flex align-items-center small fw-bold"
             >
-              <a href="./components/communication-libs.html" target="_blank">Communication libraries</a>
+              Communication libraries
             </div>
           </div>
           <div class="col-8">
@@ -92,7 +92,7 @@
             <div
               class="rocm-docs-core-sdk-tile bg-amd-blue p-2 h-100 d-flex align-items-center small fw-bold"
             >
-              <a href="./components/media-libs.html" target="_blank">Media libraries</a>
+              Media libraries
             </div>
           </div>
           <div class="col-8">
@@ -131,7 +131,7 @@
             <div
               class="rocm-docs-core-sdk-tile bg-amd-blue p-2 h-100 d-flex align-items-center small fw-bold"
             >
-              <a href="./components/runtimes-and-compilers.html" target="_blank">Runtime and compilers</a>
+              Runtime and compilers
             </div>
           </div>
           <div class="col-8">
@@ -153,7 +153,7 @@
             <div
               class="rocm-docs-core-sdk-tile bg-amd-blue p-2 h-100 d-flex align-items-center small fw-bold"
             >
-              <a href="./components/profilers-and-debuggers.html" target="_blank">Profiling and debugging tools</a>
+              Profiling and debugging tools
             </div>
           </div>
           <div class="col-8">
@@ -189,7 +189,7 @@
                 small fw-bold
               "
             >
-              <a href="./components/control-and-monitoring-tools.html" target="_blank">Control and monitoring tools</a>
+              Control and monitoring tools
             </div>
           </div>
           <div class="col-8">

--- a/docs/frameworks/jax/install.rst
+++ b/docs/frameworks/jax/install.rst
@@ -57,7 +57,7 @@ Prerequisites
    - Ensure your system has the AMD GPU Driver (amdgpu) installed. See the
      :ref:`compat-matrix` for driver support information. For installation
      instructions, see the `AMD GPU Driver documentation
-     <https://instinct.docs.amd.com/projects/amdgpu-docs/en/31.30.0-preview/install/detailed-install/package-manager/package-manager-index.html>`__.
+     <https://instinct.docs.amd.com/projects/amdgpu-docs/en/31.30.0-preview/index.html>`__.
 
 - Ensure your system has a :ref:`supported Python version
   <rocm-compat-python>` installed and accessible: 3.11, 3.12, 3.13, or 3.14.

--- a/docs/frameworks/pytorch/install.rst
+++ b/docs/frameworks/pytorch/install.rst
@@ -83,7 +83,7 @@ Prerequisites
    - Ensure your system has the AMD GPU Driver (amdgpu) installed. See the
      :ref:`compat-matrix` for driver support information. For installation
      instructions, see the `AMD GPU Driver documentation
-     <https://instinct.docs.amd.com/projects/amdgpu-docs/en/31.30.0-preview/install/detailed-install/package-manager/package-manager-index.html>`__.
+     <https://instinct.docs.amd.com/projects/amdgpu-docs/en/31.30.0-preview/index.html>`__.
 
 - Ensure your system has a :ref:`supported Python version
   <rocm-compat-python>` installed and accessible: 3.11, 3.12, 3.13, or 3.14.

--- a/docs/reference/gpu-specs.rst
+++ b/docs/reference/gpu-specs.rst
@@ -12,8 +12,6 @@ The following tables provide an overview of the hardware specifications for AMD 
 
 For more information about ROCm hardware compatibility, see the ROCm `Compatibility matrix <https://rocm.docs.amd.com/en/latest/compatibility/compatibility-matrix.html>`_.
 
-For a description of the terms used in the table, see the :ref:`ROCm glossary <glossary>`.
-
 .. seealso::
 
    * :doc:`AMD GPU architectures <gpu-arch/index>` -- microarchitecture

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -249,18 +249,7 @@ subtrees:
                   title: Set the number of CUs
           - file: reference/hip-programming.rst
             title: AMD GPU programming on ROCm
-          - file: reference/glossary.rst
-            title: ROCm glossary
-            subtrees:
-            - entries:
-              - file: reference/glossary/device-hardware.rst
-                title: Device hardware
-              - file: reference/glossary/device-software.rst
-                title: Device software
-              - file: reference/glossary/host-software.rst
-                title: Host software
-              - file: reference/glossary/performance.rst
-                title: Performance
+
     # - caption: About
     #   entries:
     #       - file: about/license.md


### PR DESCRIPTION
## Motivation

Replace staging URL with the public docs URL in the transition guide.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.