### PR TITLE
[docs/7.13.0] fix(pytorch): single-line pip install cmd for windows

### DIFF
--- a/docs/frameworks/pytorch/install.rst
+++ b/docs/frameworks/pytorch/install.rst
@@ -162,7 +162,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx950-dcgpu/ "torch==2.10.0+rocm7.13.0" "torchvision==0.25.0+rocm7.13.0" "torchaudio==2.10.0+rocm7.13.0"
 
@@ -179,7 +179,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx950-dcgpu/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
@@ -198,7 +198,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx94X-dcgpu/ "torch==2.11.0+rocm7.13.0" "torchvision==0.26.0+rocm7.13.0" "torchaudio==2.11.0+rocm7.13.0"
 
@@ -215,7 +215,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx94X-dcgpu/ "torch==2.10.0+rocm7.13.0" "torchvision==0.25.0+rocm7.13.0" "torchaudio==2.10.0+rocm7.13.0"
 
@@ -232,7 +232,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx94X-dcgpu/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
@@ -251,7 +251,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx90a/ "torch==2.11.0+rocm7.13.0" "torchvision==0.26.0+rocm7.13.0" "torchaudio==2.11.0+rocm7.13.0"
 
@@ -268,7 +268,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx90a/ "torch==2.10.0+rocm7.13.0" "torchvision==0.25.0+rocm7.13.0" "torchaudio==2.10.0+rocm7.13.0"
 
@@ -285,7 +285,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx90a/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
@@ -304,7 +304,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx908/ "torch==2.11.0+rocm7.13.0" "torchvision==0.26.0+rocm7.13.0" "torchaudio==2.11.0+rocm7.13.0"
 
@@ -319,6 +319,12 @@ Install PyTorch using pip
                    "torchvision==0.25.0+rocm7.13.0" \
                    "torchaudio==2.10.0+rocm7.13.0"
 
+         .. selected:: os=windows
+
+            .. code-block:: bat
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx908/ "torch==2.10.0+rocm7.13.0" "torchvision==0.25.0+rocm7.13.0" "torchaudio==2.10.0+rocm7.13.0"
+
       .. selected:: pytorch-ver=2.9.1
 
          .. selected:: os=linux
@@ -332,7 +338,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx908/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
@@ -379,7 +385,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx120X-all/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
@@ -426,7 +432,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx110X-all/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
@@ -462,7 +468,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx103X-all/ "torch==2.10.0+rocm7.13.0" "torchvision==0.25.0+rocm7.13.0" "torchaudio==2.10.0+rocm7.13.0"
 
@@ -479,7 +485,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx103X-all/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
@@ -526,7 +532,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
@@ -562,7 +568,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1150/ "torch==2.10.0+rocm7.13.0" "torchvision==0.25.0+rocm7.13.0" "torchaudio==2.10.0+rocm7.13.0"
 
@@ -576,6 +582,12 @@ Install PyTorch using pip
                    "torch==2.9.1+rocm7.13.0" \
                    "torchvision==0.24.0+rocm7.13.0" \
                    "torchaudio==2.9.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bat
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1150/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
    .. selected:: gfx=gfx1152
 
@@ -609,7 +621,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1152/ "torch==2.10.0+rocm7.13.0" "torchvision==0.25.0+rocm7.13.0" "torchaudio==2.10.0+rocm7.13.0"
 
@@ -626,13 +638,7 @@ Install PyTorch using pip
 
          .. selected:: os=windows
 
-            .. code-block:: bash
-
-               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1152/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
-
-         .. selected:: os=windows
-
-            .. code-block:: bash
+            .. code-block:: bat
 
                python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1152/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 

--- a/docs/frameworks/pytorch/install.rst
+++ b/docs/frameworks/pytorch/install.rst
@@ -134,291 +134,507 @@ Install PyTorch using pip
 
       .. selected:: pytorch-ver=2.11.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx950-dcgpu/ \
-                "torch==2.11.0+rocm7.13.0" \
-                "torchvision==0.26.0+rocm7.13.0" \
-                "torchaudio==2.11.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx950-dcgpu/ \
+                   "torch==2.11.0+rocm7.13.0" \
+                   "torchvision==0.26.0+rocm7.13.0" \
+                   "torchaudio==2.11.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bat
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx950-dcgpu/ "torch==2.11.0+rocm7.13.0" "torchvision==0.26.0+rocm7.13.0" "torchaudio==2.11.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.10.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx950-dcgpu/ \
-                "torch==2.10.0+rocm7.13.0" \
-                "torchvision==0.25.0+rocm7.13.0" \
-                "torchaudio==2.10.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx950-dcgpu/ \
+                   "torch==2.10.0+rocm7.13.0" \
+                   "torchvision==0.25.0+rocm7.13.0" \
+                   "torchaudio==2.10.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx950-dcgpu/ "torch==2.10.0+rocm7.13.0" "torchvision==0.25.0+rocm7.13.0" "torchaudio==2.10.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.9.1
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx950-dcgpu/ \
-                "torch==2.9.1+rocm7.13.0" \
-                "torchvision==0.24.0+rocm7.13.0" \
-                "torchaudio==2.9.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx950-dcgpu/ \
+                   "torch==2.9.1+rocm7.13.0" \
+                   "torchvision==0.24.0+rocm7.13.0" \
+                   "torchaudio==2.9.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx950-dcgpu/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
    .. selected:: gfx=gfx942
 
       .. selected:: pytorch-ver=2.11.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx94X-dcgpu/ \
-                "torch==2.11.0+rocm7.13.0" \
-                "torchvision==0.26.0+rocm7.13.0" \
-                "torchaudio==2.11.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx94X-dcgpu/ \
+                   "torch==2.11.0+rocm7.13.0" \
+                   "torchvision==0.26.0+rocm7.13.0" \
+                   "torchaudio==2.11.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx94X-dcgpu/ "torch==2.11.0+rocm7.13.0" "torchvision==0.26.0+rocm7.13.0" "torchaudio==2.11.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.10.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx94X-dcgpu/ \
-                "torch==2.10.0+rocm7.13.0" \
-                "torchvision==0.25.0+rocm7.13.0" \
-                "torchaudio==2.10.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx94X-dcgpu/ \
+                   "torch==2.10.0+rocm7.13.0" \
+                   "torchvision==0.25.0+rocm7.13.0" \
+                   "torchaudio==2.10.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx94X-dcgpu/ "torch==2.10.0+rocm7.13.0" "torchvision==0.25.0+rocm7.13.0" "torchaudio==2.10.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.9.1
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx94X-dcgpu/ \
-                "torch==2.9.1+rocm7.13.0" \
-                "torchvision==0.24.0+rocm7.13.0" \
-                "torchaudio==2.9.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx94X-dcgpu/ \
+                   "torch==2.9.1+rocm7.13.0" \
+                   "torchvision==0.24.0+rocm7.13.0" \
+                   "torchaudio==2.9.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx94X-dcgpu/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
    .. selected:: gfx=gfx90a
 
       .. selected:: pytorch-ver=2.11.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx90a/ \
-                "torch==2.11.0+rocm7.13.0" \
-                "torchvision==0.26.0+rocm7.13.0" \
-                "torchaudio==2.11.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx90a/ \
+                   "torch==2.11.0+rocm7.13.0" \
+                   "torchvision==0.26.0+rocm7.13.0" \
+                   "torchaudio==2.11.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx90a/ "torch==2.11.0+rocm7.13.0" "torchvision==0.26.0+rocm7.13.0" "torchaudio==2.11.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.10.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx90a/ \
-                "torch==2.10.0+rocm7.13.0" \
-                "torchvision==0.25.0+rocm7.13.0" \
-                "torchaudio==2.10.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx90a/ \
+                   "torch==2.10.0+rocm7.13.0" \
+                   "torchvision==0.25.0+rocm7.13.0" \
+                   "torchaudio==2.10.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx90a/ "torch==2.10.0+rocm7.13.0" "torchvision==0.25.0+rocm7.13.0" "torchaudio==2.10.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.9.1
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx90a/ \
-                "torch==2.9.1+rocm7.13.0" \
-                "torchvision==0.24.0+rocm7.13.0" \
-                "torchaudio==2.9.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx90a/ \
+                   "torch==2.9.1+rocm7.13.0" \
+                   "torchvision==0.24.0+rocm7.13.0" \
+                   "torchaudio==2.9.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx90a/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
    .. selected:: gfx=gfx908
 
       .. selected:: pytorch-ver=2.11.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx908/ \
-                "torch==2.11.0+rocm7.13.0" \
-                "torchvision==0.26.0+rocm7.13.0" \
-                "torchaudio==2.11.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx908/ \
+                   "torch==2.11.0+rocm7.13.0" \
+                   "torchvision==0.26.0+rocm7.13.0" \
+                   "torchaudio==2.11.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx908/ "torch==2.11.0+rocm7.13.0" "torchvision==0.26.0+rocm7.13.0" "torchaudio==2.11.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.10.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx908/ \
-                "torch==2.10.0+rocm7.13.0" \
-                "torchvision==0.25.0+rocm7.13.0" \
-                "torchaudio==2.10.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx908/ \
+                   "torch==2.10.0+rocm7.13.0" \
+                   "torchvision==0.25.0+rocm7.13.0" \
+                   "torchaudio==2.10.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.9.1
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx908/ \
-                "torch==2.9.1+rocm7.13.0" \
-                "torchvision==0.24.0+rocm7.13.0" \
-                "torchaudio==2.9.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx908/ \
+                   "torch==2.9.1+rocm7.13.0" \
+                   "torchvision==0.24.0+rocm7.13.0" \
+                   "torchaudio==2.9.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx908/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
    .. selected:: gfx=gfx1201 gfx=gfx1200
 
       .. selected:: pytorch-ver=2.11.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx120X-all/ \
-                "torch==2.11.0+rocm7.13.0" \
-                "torchvision==0.26.0+rocm7.13.0" \
-                "torchaudio==2.11.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx120X-all/ \
+                   "torch==2.11.0+rocm7.13.0" \
+                   "torchvision==0.26.0+rocm7.13.0" \
+                   "torchaudio==2.11.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bat
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx120X-all/ "torch==2.11.0+rocm7.13.0" "torchvision==0.26.0+rocm7.13.0" "torchaudio==2.11.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.10.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx120X-all/ \
-                "torch==2.10.0+rocm7.13.0" \
-                "torchvision==0.25.0+rocm7.13.0" \
-                "torchaudio==2.10.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx120X-all/ \
+                   "torch==2.10.0+rocm7.13.0" \
+                   "torchvision==0.25.0+rocm7.13.0" \
+                   "torchaudio==2.10.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.9.1
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx120X-all/ \
-                "torch==2.9.1+rocm7.13.0" \
-                "torchvision==0.24.0+rocm7.13.0" \
-                "torchaudio==2.9.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx120X-all/ \
+                   "torch==2.9.1+rocm7.13.0" \
+                   "torchvision==0.24.0+rocm7.13.0" \
+                   "torchaudio==2.9.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx120X-all/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
    .. selected:: gfx=gfx1100 gfx=gfx1101 gfx=gfx1102 gfx=gfx1103
 
       .. selected:: pytorch-ver=2.11.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx110X-all/ \
-                "torch==2.11.0+rocm7.13.0" \
-                "torchvision==0.26.0+rocm7.13.0" \
-                "torchaudio==2.11.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx110X-all/ \
+                   "torch==2.11.0+rocm7.13.0" \
+                   "torchvision==0.26.0+rocm7.13.0" \
+                   "torchaudio==2.11.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bat
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx110X-all/ "torch==2.11.0+rocm7.13.0" "torchvision==0.26.0+rocm7.13.0" "torchaudio==2.11.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.10.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx110X-all/ \
-                "torch==2.10.0+rocm7.13.0" \
-                "torchvision==0.25.0+rocm7.13.0" \
-                "torchaudio==2.10.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx110X-all/ \
+                   "torch==2.10.0+rocm7.13.0" \
+                   "torchvision==0.25.0+rocm7.13.0" \
+                   "torchaudio==2.10.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.9.1
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx110X-all/ \
-                "torch==2.9.1+rocm7.13.0" \
-                "torchvision==0.24.0+rocm7.13.0" \
-                "torchaudio==2.9.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx110X-all/ \
+                   "torch==2.9.1+rocm7.13.0" \
+                   "torchvision==0.24.0+rocm7.13.0" \
+                   "torchaudio==2.9.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx110X-all/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
    .. selected:: gfx=gfx1030
 
       .. selected:: pytorch-ver=2.11.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx103X-all/ \
-                "torch==2.11.0+rocm7.13.0" \
-                "torchvision==0.26.0+rocm7.13.0" \
-                "torchaudio==2.11.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx103X-all/ \
+                   "torch==2.11.0+rocm7.13.0" \
+                   "torchvision==0.26.0+rocm7.13.0" \
+                   "torchaudio==2.11.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bat
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx103X-all/ "torch==2.11.0+rocm7.13.0" "torchvision==0.26.0+rocm7.13.0" "torchaudio==2.11.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.10.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx103X-all/ \
-                "torch==2.10.0+rocm7.13.0" \
-                "torchvision==0.25.0+rocm7.13.0" \
-                "torchaudio==2.10.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx103X-all/ \
+                   "torch==2.10.0+rocm7.13.0" \
+                   "torchvision==0.25.0+rocm7.13.0" \
+                   "torchaudio==2.10.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx103X-all/ "torch==2.10.0+rocm7.13.0" "torchvision==0.25.0+rocm7.13.0" "torchaudio==2.10.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.9.1
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx103X-all/ \
-                "torch==2.9.1+rocm7.13.0" \
-                "torchvision==0.24.0+rocm7.13.0" \
-                "torchaudio==2.9.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx103X-all/ \
+                   "torch==2.9.1+rocm7.13.0" \
+                   "torchvision==0.24.0+rocm7.13.0" \
+                   "torchaudio==2.9.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx103X-all/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
    .. selected:: gfx=gfx1151
 
       .. selected:: pytorch-ver=2.11.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ \
-                "torch==2.11.0+rocm7.13.0" \
-                "torchvision==0.26.0+rocm7.13.0" \
-                "torchaudio==2.11.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ \
+                   "torch==2.11.0+rocm7.13.0" \
+                   "torchvision==0.26.0+rocm7.13.0" \
+                   "torchaudio==2.11.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bat
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ "torch==2.11.0+rocm7.13.0" "torchvision==0.26.0+rocm7.13.0" "torchaudio==2.11.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.10.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ \
-                "torch==2.10.0+rocm7.13.0" \
-                "torchvision==0.25.0+rocm7.13.0" \
-                "torchaudio==2.10.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ \
+                   "torch==2.10.0+rocm7.13.0" \
+                   "torchvision==0.25.0+rocm7.13.0" \
+                   "torchaudio==2.10.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.9.1
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ \
-                "torch==2.9.1+rocm7.13.0" \
-                "torchvision==0.24.0+rocm7.13.0" \
-                "torchaudio==2.9.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ \
+                   "torch==2.9.1+rocm7.13.0" \
+                   "torchvision==0.24.0+rocm7.13.0" \
+                   "torchaudio==2.9.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1151/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
    .. selected:: gfx=gfx1150
 
       .. selected:: pytorch-ver=2.11.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1150/ \
-                "torch==2.11.0+rocm7.13.0" \
-                "torchvision==0.26.0+rocm7.13.0" \
-                "torchaudio==2.11.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1150/ \
+                   "torch==2.11.0+rocm7.13.0" \
+                   "torchvision==0.26.0+rocm7.13.0" \
+                   "torchaudio==2.11.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bat
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1150/ "torch==2.11.0+rocm7.13.0" "torchvision==0.26.0+rocm7.13.0" "torchaudio==2.11.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.10.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1150/ \
-                "torch==2.10.0+rocm7.13.0" \
-                "torchvision==0.25.0+rocm7.13.0" \
-                "torchaudio==2.10.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1150/ \
+                   "torch==2.10.0+rocm7.13.0" \
+                   "torchvision==0.25.0+rocm7.13.0" \
+                   "torchaudio==2.10.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1150/ "torch==2.10.0+rocm7.13.0" "torchvision==0.25.0+rocm7.13.0" "torchaudio==2.10.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.9.1
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1150/ \
-                "torch==2.9.1+rocm7.13.0" \
-                "torchvision==0.24.0+rocm7.13.0" \
-                "torchaudio==2.9.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1150/ \
+                   "torch==2.9.1+rocm7.13.0" \
+                   "torchvision==0.24.0+rocm7.13.0" \
+                   "torchaudio==2.9.0+rocm7.13.0"
 
    .. selected:: gfx=gfx1152
 
       .. selected:: pytorch-ver=2.11.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1152/ \
-                "torch==2.11.0+rocm7.13.0" \
-                "torchvision==0.26.0+rocm7.13.0" \
-                "torchaudio==2.11.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1152/ \
+                   "torch==2.11.0+rocm7.13.0" \
+                   "torchvision==0.26.0+rocm7.13.0" \
+                   "torchaudio==2.11.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bat
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1152/ "torch==2.11.0+rocm7.13.0" "torchvision==0.26.0+rocm7.13.0" "torchaudio==2.11.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.10.0
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1152/ \
-                "torch==2.10.0+rocm7.13.0" \
-                "torchvision==0.25.0+rocm7.13.0" \
-                "torchaudio==2.10.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1152/ \
+                   "torch==2.10.0+rocm7.13.0" \
+                   "torchvision==0.25.0+rocm7.13.0" \
+                   "torchaudio==2.10.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1152/ "torch==2.10.0+rocm7.13.0" "torchvision==0.25.0+rocm7.13.0" "torchaudio==2.10.0+rocm7.13.0"
 
       .. selected:: pytorch-ver=2.9.1
 
-         .. code-block:: bash
+         .. selected:: os=linux
 
-            python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1152/ \
-                "torch==2.9.1+rocm7.13.0" \
-                "torchvision==0.24.0+rocm7.13.0" \
-                "torchaudio==2.9.0+rocm7.13.0"
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1152/ \
+                   "torch==2.9.1+rocm7.13.0" \
+                   "torchvision==0.24.0+rocm7.13.0" \
+                   "torchaudio==2.9.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1152/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
+
+         .. selected:: os=windows
+
+            .. code-block:: bash
+
+               python -m pip install --index-url https://repo.amd.com/rocm/whl/gfx1152/ "torch==2.9.1+rocm7.13.0" "torchvision==0.24.0+rocm7.13.0" "torchaudio==2.9.0+rocm7.13.0"
 
 4. Verify your PyTorch installation.
 


### PR DESCRIPTION
## Motivation

The Windows instructions for PyTorch incorrectly use `\` for line continuations.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
