### PR TITLE
[docs/7.13.0] installation: remove configure GPU permissions step for Ubuntu 26.04

### DIFF
--- a/docs/install/include/100-prerequisites.rst
+++ b/docs/install/include/100-prerequisites.rst
@@ -683,7 +683,7 @@ Prerequisites
          :heading: Configure permissions for GPU access
          :heading-level: 3
 
-         There are two primary methods of configuring GPU access for ROCm: group
+         There are two primary methods for configuring GPU access for ROCm: group
          membership or udev rules. Each method has its own advantages. The choice
          depends on your specific requirements and system management preferences.
 
@@ -726,7 +726,7 @@ Prerequisites
       :heading: Configure permissions for GPU access
       :heading-level: 3
 
-      There are two primary methods of configuring GPU access for ROCm: group
+      There are two primary methods for configuring GPU access for ROCm: group
       membership or udev rules. Each method has its own advantages. The choice
       depends on your specific requirements and system management preferences.
 
@@ -771,7 +771,7 @@ Prerequisites
       :heading: Configure permissions for GPU access
       :heading-level: 3
 
-      There are two primary methods of configuring GPU access for ROCm: group
+      There are two primary methods for configuring GPU access for ROCm: group
       membership or udev rules. Each method has its own advantages. The choice
       depends on your specific requirements and system management preferences.
 

--- a/docs/install/include/100-prerequisites.rst
+++ b/docs/install/include/100-prerequisites.rst
@@ -677,7 +677,52 @@ Prerequisites
 
 .. selected:: i=pkgman i=pip i=tar
 
-   .. selected:: os=ubuntu os=debian os=rhel os=oracle-linux os=rocky-linux os=sles os=wsl
+   .. selected:: os=ubuntu
+
+      .. selected:: ubuntu-ver=24.04 ubuntu-ver=22.04
+         :heading: Configure permissions for GPU access
+         :heading-level: 3
+
+         There are two primary methods of configuring GPU access for ROCm: group
+         membership or udev rules. Each method has its own advantages. The choice
+         depends on your specific requirements and system management preferences.
+
+         .. tab-set::
+
+            .. tab-item:: Group membership
+
+               By default, GPU access is controlled by membership in the ``video`` and
+               ``render`` Linux system groups. The ``video`` group traditionally handles
+               video device access, while the ``render`` group manages GPU rendering
+               through DRM render nodes.
+
+               .. code-block:: bash
+
+                  # Add the current user to the render and video groups
+                  sudo usermod -a -G render,video $LOGNAME
+
+            .. tab-item:: udev rules
+
+               udev rules are a flexible, system-wide approach for managing device
+               permissions, eliminating the need for user group management while
+               allowing granular GPU access. To enable them and grant GPU access to
+               all users, run the following command:
+
+               .. code-block:: bash
+
+                  sudo tee /etc/udev/rules.d/70-amdgpu.rules << EOF
+                  KERNEL=="kfd", GROUP="render", MODE="0666"
+                  SUBSYSTEM=="drm", KERNEL=="renderD*", GROUP="render", MODE="0666"
+                  EOF
+
+                  sudo udevadm control --reload-rules
+                  sudo udevadm trigger
+
+         .. note::
+
+            To apply all settings, reboot your system.
+
+   .. selected:: os=debian os=rhel os=oracle-linux os=rocky-linux os=sles os=wsl
       :heading: Configure permissions for GPU access
       :heading-level: 3
 


### PR DESCRIPTION
## Motivation

Remove "Configure GPU access permissions" step for Ubuntu 26.04.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Specify including this step for Ubuntu 24.04 and 22.04. Don't specify 26.04.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
