### PR TITLE
Remove stored token logging from autotag script

### DIFF
--- a/tools/autotag/tag_script.py
+++ b/tools/autotag/tag_script.py
@@ -41,7 +41,6 @@ def get_token(
                     "No token was passed, and no stored token could be found."
                 )
             used_token = used_token_bytes.decode()
-            print(f"Using stored token: {used_token}")
         if isinstance(token_keys, str):
             db[token_keys] = used_token
         elif isinstance(token_keys, list):


### PR DESCRIPTION
## Summary
- Remove the log line that printed a stored GitHub token from the autotag script.

## Why
`get_token()` retrieved stored credentials and printed the full token value. That could expose a personal access token in CI logs or terminal scrollback.

## Validation
- `python3 -m py_compile tools/autotag/tag_script.py`
- `git diff --check`
- Confirmed the old `Using stored token` log string is no longer present.