### PR TITLE
docs: update RCCL links to new rocm-systems repo location

### DIFF
--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -64,7 +64,7 @@ additional licenses. Please review individual repositories for more information.
 | [rocminfo](https://github.com/ROCm/rocm-systems/tree/develop/projects/rocminfo/) | [The University of Illinois/NCSA](https://github.com/ROCm/rocm-systems/blob/develop/projects/rocminfo/License.txt) |
 | [ROCm Bandwidth Test](https://github.com/ROCm/rocm_bandwidth_test/) | [MIT](https://github.com/ROCm/rocm_bandwidth_test/blob/master/LICENSE.txt) |
 | [ROCm CMake](https://github.com/ROCm/rocm-cmake/) | [MIT](https://github.com/ROCm/rocm-cmake/blob/develop/LICENSE) |
-| [ROCm Communication Collectives Library (RCCL)](https://github.com/ROCm/rccl/) | [Custom](https://github.com/ROCm/rccl/blob/develop/LICENSE.txt) |
+| [ROCm Communication Collectives Library (RCCL)](https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl) | [Custom](https://github.com/ROCm/rocm-systems/blob/develop/projects/rccl/LICENSE.txt) |
 | [ROCm-Core](https://github.com/ROCm/rocm-systems/tree/develop/projects/rocm-core/) | [MIT](https://github.com/ROCm/rocm-systems/blob/develop/projects/rocm-core/LICENSE.md) |
 | [ROCm Compute Profiler](https://github.com/ROCm/rocm-systems/tree/develop/projects/rocprofiler-compute/) | [MIT](https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-compute/LICENSE.md) |
 | [ROCm Data Center (RDC)](https://github.com/ROCm/rocm-systems/tree/develop/projects/rdc/) | [MIT](https://github.com/ROCm/rocm-systems/blob/develop/projects/rdc/LICENSE.md) |

--- a/docs/compatibility/ml-compatibility/dgl-compatibility.rst
+++ b/docs/compatibility/ml-compatibility/dgl-compatibility.rst
@@ -235,7 +235,7 @@ If you prefer to build it yourself, ensure the following dependencies are instal
       - 2.2.0
       - Accelerates the data pipeline by offloading intensive preprocessing and
         augmentation tasks. rocAL is part of MIVisionX.
-    * - `RCCL <https://github.com/ROCm/rccl>`_
+    * - `RCCL <https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl>`_
       - 2.26.6
       - 2.22.3
       - Optimizes for multi-GPU communication for operations like AllReduce and

--- a/docs/compatibility/ml-compatibility/jax-compatibility.rst
+++ b/docs/compatibility/ml-compatibility/jax-compatibility.rst
@@ -169,7 +169,7 @@ depend on the specific implementation and operations performed.
       - :version-ref:`MIOpen rocm_version`
       - Optimized for deep learning primitives such as convolutions, pooling,
         normalization, and activation functions.
-    * - `RCCL <https://github.com/ROCm/rccl>`_
+    * - `RCCL <https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl>`_
       - :version-ref:`RCCL rocm_version`
       - Optimized for multi-GPU communication for operations like  all-reduce,
         broadcast, and scatter.

--- a/docs/compatibility/ml-compatibility/pytorch-compatibility.rst
+++ b/docs/compatibility/ml-compatibility/pytorch-compatibility.rst
@@ -13,7 +13,7 @@ PyTorch compatibility
 `PyTorch <https://pytorch.org/>`__ is an open-source tensor library designed for
 deep learning. PyTorch on ROCm provides mixed-precision and large-scale training
 using `MIOpen <https://github.com/ROCm/MIOpen>`__ and
-`RCCL <https://github.com/ROCm/rccl>`__ libraries.
+`RCCL <https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl>`__ libraries.
 
 PyTorch provides two high-level features:
 
@@ -197,7 +197,7 @@ feature set available to developers.
         augmentation tasks. rocAL is part of MIVisionX.
       - Easy to integrate into PyTorch's ``torch.utils.data`` and
         ``torchvision`` data load workloads.
-    * - `RCCL <https://github.com/ROCm/rccl>`__
+    * - `RCCL <https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl>`__
       - :version-ref:`RCCL rocm_version`
       - Optimizes for multi-GPU communication for operations like AllReduce and
         Broadcast.

--- a/docs/compatibility/ml-compatibility/tensorflow-compatibility.rst
+++ b/docs/compatibility/ml-compatibility/tensorflow-compatibility.rst
@@ -115,7 +115,7 @@ are available in ROCm :version:`rocm_version`.
       - Speeds up convolutional neural networks (CNNs) and other layers. Used
         in TensorFlow for layers like ``tf.nn.conv2d``, ``tf.nn.relu``, and
         ``tf.nn.lstm_cell``.
-    * - `RCCL <https://github.com/ROCm/rccl>`__
+    * - `RCCL <https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl>`__
       - :version-ref:`RCCL rocm_version`
       - Optimizes for multi-GPU communication for operations like AllReduce and
         Broadcast.

--- a/docs/how-to/rocm-for-ai/inference-optimization/workload.rst
+++ b/docs/how-to/rocm-for-ai/inference-optimization/workload.rst
@@ -1515,7 +1515,7 @@ Run RCCL-Unittests
 
 In order to verify RCCL installation and test whether all parts and
 units of RCCL work as expected you can run the RCCL-Unittests which is
-explained in `<https://github.com/ROCm/rccl?tab=readme-ov-file#tests>`__.
+explained in `<https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl#tests>`__.
 
 .. _mi300x-rccl-npkit:
 
@@ -1524,7 +1524,7 @@ NPKit profiler
 
 To collect fine-grained trace events in RCCL components, especially in
 giant collective GPU kernels you can use the NPKit profiler explained
-in `<https://github.com/ROCm/rccl?tab=readme-ov-file#npkit>`__.
+in `<https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl>`__.
 
 .. _mi300x-rccl-tests:
 

--- a/docs/reference/graph-safe-support.rst
+++ b/docs/reference/graph-safe-support.rst
@@ -56,7 +56,7 @@ The following table shows whether a ROCm library is graph-safe.
       - `MIOpen <https://github.com/ROCm/MIOpen>`_
       - ❌
     * 
-      - `RCCL <https://github.com/ROCm/rccl>`_
+      - `RCCL <https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl>`_
       - ✅
     * 
       - `rocAL <https://github.com/ROCm/rocAL>`_


### PR DESCRIPTION
## Summary

`ROCm/rccl` is deprecated and has moved to `ROCm/rocm-systems` under `projects/rccl/`. This PR updates all stale documentation links in active docs to point to the new location.

**Old:** `https://github.com/ROCm/rccl`
**New:** `https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl`

### Files updated
- `docs/about/license.md` — library link + LICENSE.txt URL
- `docs/compatibility/ml-compatibility/pytorch-compatibility.rst` — 2 links
- `docs/compatibility/ml-compatibility/tensorflow-compatibility.rst` — 1 link
- `docs/compatibility/ml-compatibility/jax-compatibility.rst` — 1 link
- `docs/compatibility/ml-compatibility/dgl-compatibility.rst` — 1 link
- `docs/reference/graph-safe-support.rst` — 1 link
- `docs/how-to/rocm-for-ai/inference-optimization/workload.rst` — `#tests` anchor + NPKit reference (no `#npkit` anchor exists in new README; linked to main RCCL page instead)

### Not changed
- Historical/versioned content (`tools/autotag/`, `RELEASE.md`, `docs/data/.../previous-versions/`) — these are intentionally preserved as historical records
- `rccl-tests` URLs — the new RCCL README still references `ROCm/rccl-tests` for performance tests

## Test plan
- [ ] Verify all updated URLs resolve to the correct pages on `github.com/ROCm/rocm-systems`
- [ ] Confirm no other active docs reference `github.com/ROCm/rccl` (non-tests)