### PR TITLE
docs: update composable_kernel and rocm-core links to new repo locations

### DIFF
--- a/docs/compatibility/compatibility-matrix.rst
+++ b/docs/compatibility/compatibility-matrix.rst
@@ -111,7 +111,7 @@ compatibility and system requirements.
       ,,,
       SUPPORT LIBS,,,
       `hipother <https://github.com/ROCm/hipother>`_,7.2.53211,7.2.53211,7.1.25424
-      `rocm-core <https://github.com/ROCm/rocm-core>`_,7.2.4/7.2.3,7.2.2/7.2.1,7.1.0
+      `rocm-core <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocm-core>`_,7.2.4/7.2.3,7.2.2/7.2.1,7.1.0
       `ROCT-Thunk-Interface <https://github.com/ROCm/ROCT-Thunk-Interface>`_,N/A [#ROCT-rocr]_,N/A [#ROCT-rocr]_,N/A [#ROCT-rocr]_
       ,,,
       SYSTEM MGMT TOOLS,.. _tools-support-compatibility-matrix:,,

--- a/docs/compatibility/ml-compatibility/dgl-compatibility.rst
+++ b/docs/compatibility/ml-compatibility/dgl-compatibility.rst
@@ -167,7 +167,7 @@ If you prefer to build it yourself, ensure the following dependencies are instal
       - ROCm 7.0.0 Version
       - ROCm 6.4.x Version
       - Purpose
-    * - `Composable Kernel <https://github.com/ROCm/composable_kernel>`_
+    * - `Composable Kernel <https://github.com/ROCm/rocm-libraries/tree/develop/projects/composablekernel>`_
       - 1.1.0
       - 1.1.0
       - Enables faster execution of core operations like matrix multiplication

--- a/docs/compatibility/ml-compatibility/pytorch-compatibility.rst
+++ b/docs/compatibility/ml-compatibility/pytorch-compatibility.rst
@@ -112,7 +112,7 @@ feature set available to developers.
       - Version
       - Purpose
       - Used in
-    * - `Composable Kernel <https://github.com/ROCm/composable_kernel>`__
+    * - `Composable Kernel <https://github.com/ROCm/rocm-libraries/tree/develop/projects/composablekernel>`__
       - :version-ref:`"Composable Kernel" rocm_version`
       - Enables faster execution of core operations like matrix multiplication
         (GEMM), convolutions and transformations.

--- a/docs/how-to/rocm-for-ai/inference-optimization/model-acceleration-libraries.rst
+++ b/docs/how-to/rocm-for-ai/inference-optimization/model-acceleration-libraries.rst
@@ -41,7 +41,7 @@ Installing Flash Attention 2
 
 `Flash Attention <https://github.com/Dao-AILab/flash-attention>`_ supports two backend implementations on AMD GPUs.
 
-*  `Composable Kernel (CK) <https://github.com/ROCm/composable_kernel>`__ - the default backend
+*  `Composable Kernel (CK) <https://github.com/ROCm/rocm-libraries/tree/develop/projects/composablekernel>`__ - the default backend
 *  `OpenAI Triton <https://github.com/triton-lang/triton>`__ - an alternative backend
 
 You can switch between these backends using the environment variable ``FLASH_ATTENTION_TRITON_AMD_ENABLE``:

--- a/docs/how-to/rocm-for-ai/inference-optimization/optimizing-with-composable-kernel.md
+++ b/docs/how-to/rocm-for-ai/inference-optimization/optimizing-with-composable-kernel.md
@@ -166,7 +166,7 @@ Second, consider whether the format of input data meets your actual calculation 
 
 Third, consider the platform for implementing CK instances. The instances suffixed with `xdl` only run on AMD Instinct GPUs after being compiled and cannot run on Radeon-Series GPUs. This is due to the underlying device-specific instruction sets for implementing these basic instances.
 
-Here, we use [DeviceBatchedGemmMultiD_Xdl](https://github.com/ROCm/composable_kernel/tree/develop/example/24_batched_gemm) as the fundamental instance to implement the functionalities in the previous table.
+Here, we use [DeviceBatchedGemmMultiD_Xdl](https://github.com/ROCm/rocm-libraries/tree/develop/projects/composablekernel/example/24_batched_gemm) as the fundamental instance to implement the functionalities in the previous table.
 
 <!-- 
 ================

--- a/docs/reference/graph-safe-support.rst
+++ b/docs/reference/graph-safe-support.rst
@@ -23,7 +23,7 @@ The following table shows whether a ROCm library is graph-safe.
       - ROCm library
       - Graph safe support
     * 
-      - `Composable Kernel <https://github.com/ROCm/composable_kernel>`_
+      - `Composable Kernel <https://github.com/ROCm/rocm-libraries/tree/develop/projects/composablekernel>`_
       - ❌
     * 
       - `hipBLAS <https://github.com/ROCm/hipBLAS>`_


### PR DESCRIPTION
## Summary

Two ROCm repositories have been deprecated and consolidated into monorepos, but documentation links still point to the old standalone repos:

- `ROCm/composable_kernel` → deprecated, moved to `ROCm/rocm-libraries` under `projects/composablekernel`
- `ROCm/rocm-core` → deprecated, moved to `ROCm/rocm-systems` under `projects/rocm-core`

This PR updates all stale links in active documentation to point to the new locations.

### Files updated

| File | Change |
|---|---|
| `docs/compatibility/ml-compatibility/dgl-compatibility.rst` | composable_kernel link |
| `docs/compatibility/ml-compatibility/pytorch-compatibility.rst` | composable_kernel link |
| `docs/how-to/rocm-for-ai/inference-optimization/optimizing-with-composable-kernel.md` | composable_kernel deep link (example path) |
| `docs/how-to/rocm-for-ai/inference-optimization/model-acceleration-libraries.rst` | composable_kernel link |
| `docs/reference/graph-safe-support.rst` | composable_kernel link |
| `docs/compatibility/compatibility-matrix.rst` | rocm-core link |