### PR TITLE
fix: correct ReleaseBundle default_factory and hipify lib_version extraction

### DIFF
--- a/tools/autotag/util/custom_templates/hipify.py
+++ b/tools/autotag/util/custom_templates/hipify.py
@@ -21,7 +21,7 @@ def hipify_processor(data: ReleaseLib, template: str, _, __) -> bool:
     changelog = changelog.decoded_content.decode()
     pattern = re.compile(template)
     match = pattern.search(changelog)
-    lib_version  = match["rocm_version"]
+    lib_version = match["lib_version"] or match["rocm_version"]
 
     data.message = (
         f"HIPIFY for ROCm"

--- a/tools/autotag/util/release_data.py
+++ b/tools/autotag/util/release_data.py
@@ -238,7 +238,7 @@ class ReleaseBundle:
     """Stores data about all the libraries bundled in this release."""
 
     version: str = ""
-    libraries: Dict[str, ReleaseLib] = field(default_factory=ReleaseLib)
+    libraries: Dict[str, ReleaseLib] = field(default_factory=dict)
 
 
 class ReleaseBundleFactory:


### PR DESCRIPTION
## Description

Two bugs in `tools/autotag/` that cause incorrect behavior in the release automation tooling.

### Bug 1 — `ReleaseBundle.libraries` wrong `default_factory`

**File:** `tools/autotag/util/release_data.py`

`ReleaseBundle.libraries` is typed as `Dict[str, ReleaseLib]` but its `default_factory` was set to `ReleaseLib`, which constructs a `ReleaseLib` instance rather than an empty `dict`. Any code path that creates a `ReleaseBundle()` without an explicit `libraries=` argument and then calls `.items()` or performs key-based access on `.libraries` would raise `AttributeError` at runtime.

**Fix:** Change `default_factory=ReleaseLib` → `default_factory=dict`.

### Bug 2 — `hipify_processor` ignores the captured `lib_version` group

**File:** `tools/autotag/util/custom_templates/hipify.py`

The HIPIFY changelog template regex captures two named groups: `lib_version` and `rocm_version`. The processor assigned `match["rocm_version"]` to the `lib_version` variable, silently ignoring the explicitly captured library version. For changelog entries of the form `## HIPIFY 5.5.0 for ROCm 6.0.0`, this caused `data.lib_version` to be set to the ROCm version (`6.0.0`) instead of the HIPIFY library version (`5.5.0`).

**Fix:** Use `match["lib_version"] or match["rocm_version"]` — reads the library version when present, falls back to the ROCm version for changelog entries that omit a standalone library version (e.g. `## HIPIFY for ROCm 6.0.0`).

## Type of change

- [x] Bug fix

## Testing

- [x] Verified `ReleaseBundle()` with no arguments now produces an empty `libraries` dict
- [x] Verified `hipify_processor` correctly extracts `lib_version` from a changelog entry containing both version fields
- [x] Verified `hipify_processor` falls back to `rocm_version` when `lib_version` is absent from the changelog entry

## Checklist

- [x] Code follows the existing style of the project
- [x] Changes are limited to the described bug fixes — no unrelated modifications