### PR TITLE
[docs/7.13.0] fix: Remove incorrect Radeon product entry

### DIFF
--- a/docs/about/include/hardware-support-table.md
+++ b/docs/about/include/hardware-support-table.md
@@ -233,7 +233,6 @@
             target="_blank">Radeon RX 7800 XT</a></p>
         <p><a href="https://www.amd.com/en/products/graphics/desktops/radeon/7000-series/amd-radeon-rx-7700-xt.html"
             target="_blank">Radeon RX 7700 XT</a></p>
-        <p>Radeon RX 7700 XE</p>
         <p><a href="https://www.amd.com/en/products/graphics/desktops/radeon/7000-series/amd-radeon-rx-7700.html"
             target="_blank">Radeon RX 7700</a></p>
       </td>

--- a/docs/about/transition-guide-TheRock.md
+++ b/docs/about/transition-guide-TheRock.md
@@ -238,7 +238,7 @@ When redistributing software built on the ROCm Core SDK (for example, via contai
     <tr>
       <td>RDNA3</td>
       <td>-gfx110x</td>
-      <td>AMD Radeon RX 7700 / AMD Radeon RX 7600 / AMD Radeon PRO V710 / AMD Radeon PRO W7900 / AMD Radeon PRO W7800 / AMD Radeon PRO W7700 / AMD Radeon RX 7900 XT / AMD Radeon RX 7800 XT / AMD Radeon RX 7700 XT / AMD Radeon RX 7700 XE / AMD Radeon RX 7900 XTX / AMD Radeon RX 7900 GRE / AMD Radeon PRO W7800 48GB / AMD Radeon PRO W7900 Dual Slot</td>
+      <td>AMD Radeon RX 7700 / AMD Radeon RX 7600 / AMD Radeon PRO V710 / AMD Radeon PRO W7900 / AMD Radeon PRO W7800 / AMD Radeon PRO W7700 / AMD Radeon RX 7900 XT / AMD Radeon RX 7800 XT / AMD Radeon RX 7700 XT / AMD Radeon RX 7900 XTX / AMD Radeon RX 7900 GRE / AMD Radeon PRO W7800 48GB / AMD Radeon PRO W7900 Dual Slot</td>
     </tr>
     <tr>
       <td>RDNA2</td>

--- a/docs/ai-inference/vllm.rst
+++ b/docs/ai-inference/vllm.rst
@@ -131,9 +131,6 @@ APUs using either a prebuilt Docker image (recommended) or pip. It applies to
       .. selector-option:: AMD Radeon RX 7700 XT (gfx1101)
          :value: rx-7700-xt gfx=gfx1101
 
-      .. selector-option:: AMD Radeon RX 7700 XE (gfx1101)
-         :value: rx-7700-xe gfx=gfx1101
-
       .. selector-option:: AMD Radeon RX 7700 (gfx1101)
          :value: rx-7700 gfx=gfx1101
 

--- a/docs/gpus.yaml
+++ b/docs/gpus.yaml
@@ -292,12 +292,6 @@ amd_gpus:
     gfx: gfx1101
     family: radeon
     selector_id: rx-7700-xt
-  - marketing_name: AMD Radeon RX 7700 XE
-    short_name: RX 7700 XE
-    marketing_series: AMD Radeon RX 7000 Series
-    gfx: gfx1101
-    family: radeon
-    selector_id: rx-7700-xe
   - marketing_name: AMD Radeon RX 7700
     short_name: RX 7700
     marketing_series: AMD Radeon RX 7000 Series

--- a/docs/install/include/gpu-selector.rst
+++ b/docs/install/include/gpu-selector.rst
@@ -97,9 +97,6 @@
          .. selector-option:: AMD Radeon RX 7700 XT (gfx1101)
             :value: rx-7700-xt gfx=gfx1101
 
-         .. selector-option:: AMD Radeon RX 7700 XE (gfx1101)
-            :value: rx-7700-xe gfx=gfx1101
-
          .. selector-option:: AMD Radeon RX 7700 (gfx1101)
             :value: rx-7700 gfx=gfx1101
 

--- a/docs/install/include/ror-gpu-selector.rst
+++ b/docs/install/include/ror-gpu-selector.rst
@@ -65,9 +65,6 @@
             .. selector-option:: AMD Radeon RX 7700 XT (gfx1101)
                :value: rx-7700-xt gfx=gfx1101
 
-            .. selector-option:: AMD Radeon RX 7700 XE (gfx1101)
-               :value: rx-7700-xe gfx=gfx1101
-
             .. selector-option:: AMD Radeon RX 7700 (gfx1101)
                :value: rx-7700 gfx=gfx1101
 


### PR DESCRIPTION
## Motivation

Remove incorrect GPU entry: Radeon RX 7700 XE. Should be Radeon RX 7700 (Navi 32 XE), which is already covered.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
