### PR TITLE
docs(extras): fix TransferBench link

### DIFF
--- a/docs/components/extras.rst
+++ b/docs/components/extras.rst
@@ -19,6 +19,6 @@ for verifying hardware health, measuring system performance, and managing GPU fl
   and AMD GPU hardware. Includes tests for GPU functionality, memory, power behavior, and
   peer-to-peer communication, helping diagnose installation issues and hardware faults.
 
-  * :doc:`TransferBench <https://rocm.docs.amd.com/projects/TransferBench/en/docs-1.66.02/index.html>` -- A utility for benchmarking simultaneous memory transfers between user-specified devices (CPUs, GPUs, and NICs). This component is part of the ROCmValidationSuite (RVS) and is installed with it.
+  * `TransferBench <https://rocm.docs.amd.com/projects/TransferBench/en/latest/index.html>`_ -- A utility for benchmarking simultaneous memory transfers between user-specified devices (CPUs, GPUs, and NICs). This component is part of the ROCmValidationSuite (RVS) and is installed with it.
 
 * More coming soon.


### PR DESCRIPTION
## Motivation
Replaces a broken `:doc:` role (no intersphinx mapping exists for TransferBench) with a plain hyperlink pointing to the latest docs.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.