### PR TITLE
docs: Sort selector dropdown items

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -790,6 +790,7 @@ amdrocm
 amdsmi
 api
 aqlprofile
+asc
 async
 aten
 atmi
@@ -912,6 +913,7 @@ dequantization
 dequantized
 dequantizes
 dereference
+desc
 deserializers
 detections
 dev

--- a/docs/extension/rocm_docs_custom/selector/__init__.py
+++ b/docs/extension/rocm_docs_custom/selector/__init__.py
@@ -178,6 +178,21 @@ class _SelectorGroupBase(SphinxDirective):
 
         option_nodes = list(node.findall(SelectorOption))
         if option_nodes:
+            sort_order = self.options.get("sort", "").lower()
+            if sort_order in ("asc", "desc"):
+                reverse = sort_order == "desc"
+                sorted_options = sorted(option_nodes, key=lambda opt: opt["label"], reverse=reverse)
+                # Reorder only SelectorOption children in-place, preserving non-option siblings
+                option_positions = [i for i, c in enumerate(node.children) if isinstance(c, SelectorOption)]
+                for pos, opt in zip(option_positions, sorted_options):
+                    node.children[pos] = opt
+                option_nodes = sorted_options
+            elif sort_order:
+                logger.warning(
+                    f"Invalid ':sort:' value '{sort_order}' — expected 'asc' or 'desc'",
+                    location=(self.env.docname, self.lineno),
+                )
+
             for opt in option_nodes:
                 opt["group_key"] = node["key"]
                 opt["dropdown-input"] = self._is_dropdown
@@ -202,6 +217,7 @@ class SelectorDropdownDirective(_SelectorGroupBase):
         "key": directives.unchanged,
         "show-cond": directives.unchanged,
         "heading-width": directives.nonnegative_int,
+        "sort": directives.unchanged,
     }
     _is_dropdown = True
 

--- a/docs/extension/rocm_docs_custom/selector/__init__.py
+++ b/docs/extension/rocm_docs_custom/selector/__init__.py
@@ -188,10 +188,7 @@ class _SelectorGroupBase(SphinxDirective):
                     node.children[pos] = opt
                 option_nodes = sorted_options
             elif sort_order:
-                logger.warning(
-                    f"Invalid ':sort:' value '{sort_order}' — expected 'asc' or 'desc'",
-                    location=(self.env.docname, self.lineno),
-                )
+                raise self.error(f"Invalid ':sort:' value '{sort_order}' — expected 'asc' or 'desc'")
 
             for opt in option_nodes:
                 opt["group_key"] = node["key"]

--- a/docs/extension/rocm_docs_custom/selector/static/selector-toc2.js
+++ b/docs/extension/rocm_docs_custom/selector/static/selector-toc2.js
@@ -79,36 +79,57 @@ export function updateTOC2OptionsList() {
     selectEl.className = `form-select ${DROPDOWN_INPUT_CLASS}`;
     selectEl.name = headingText;
 
-    const options = Array.from(group.querySelectorAll(OPTION_QUERY)).filter(
-      (opt) =>
-        !opt.classList.contains(HIDDEN_CLASS) &&
-        !opt.classList.contains(DISABLED_CLASS),
-    );
+    const mainSelect = group.querySelector(`.${DROPDOWN_INPUT_CLASS}`);
+    const mainTs = mainSelect?.tomselect;
 
-    if (options.length === 0) {
+    let optionDescs;
+    if (mainTs) {
+      const selectedVal = mainTs.getValue();
+      optionDescs = Object.values(mainTs.options)
+        .filter((o) => {
+          const optEl = o.$option;
+          return (
+            !o.disabled &&
+            !optEl?.classList?.contains(HIDDEN_CLASS) &&
+            !optEl?.classList?.contains(DISABLED_CLASS)
+          );
+        })
+        .sort((a, b) => a.$order - b.$order)
+        .map((o) => ({ text: o.text, value: o.value, selected: o.value === selectedVal }));
+    } else {
+      optionDescs = Array.from(group.querySelectorAll(OPTION_QUERY))
+        .filter(
+          (opt) =>
+            !opt.classList.contains(HIDDEN_CLASS) &&
+            !opt.classList.contains(DISABLED_CLASS),
+        )
+        .map((optionEl) => {
+          const tocLabel = optionEl.getAttribute("data-toc-label");
+          let text;
+          if (tocLabel) {
+            text = tocLabel;
+          } else {
+            const clone = optionEl.cloneNode(true);
+            clone.querySelectorAll("i, svg").forEach((el) => el.remove());
+            text = clone.textContent.trim();
+          }
+          return {
+            text,
+            value: optionEl.dataset.selectorValue || "",
+            selected: optionEl.classList.contains(SELECTED_CLASS),
+          };
+        });
+    }
+
+    if (optionDescs.length === 0) {
       const opt = document.createElement("option");
       opt.textContent = "(none available)";
       opt.disabled = true;
       opt.selected = true;
       selectEl.appendChild(opt);
     } else {
-      options.forEach((optionEl) => {
-        const tocLabel = optionEl.getAttribute("data-toc-label");
-        let labelText;
-        if (tocLabel) {
-          labelText = tocLabel;
-        } else {
-          const clone = optionEl.cloneNode(true);
-          clone.querySelectorAll("i, svg").forEach((el) => el.remove());
-          labelText = clone.textContent.trim();
-        }
-        const opt = new Option(
-          labelText,
-          optionEl.dataset.selectorValue || "",
-          false,
-          optionEl.classList.contains(SELECTED_CLASS),
-        );
-        selectEl.appendChild(opt);
+      optionDescs.forEach(({ text, value, selected }) => {
+        selectEl.appendChild(new Option(text, value, false, selected));
       });
     }
 
@@ -121,9 +142,8 @@ export function updateTOC2OptionsList() {
         // For dropdown groups on the main page, drive via TomSelect so its
         // change event fires and selector.js handles the update. Calling
         // .click() on a native <option> element is unreliable across browsers.
-        const mainSelect = group.querySelector(`.${DROPDOWN_INPUT_CLASS}`);
-        if (mainSelect?.tomselect) {
-          mainSelect.tomselect.setValue(value);
+        if (mainTs) {
+          mainTs.setValue(value);
           return;
         }
         const target = group.querySelector(

--- a/docs/install/include/gpu-selector.rst
+++ b/docs/install/include/gpu-selector.rst
@@ -5,6 +5,7 @@
       .. selector-dropdown:: Instinct GPU
          :key: gpu
          :show-cond: fam=instinct
+         :sort: desc
 
          .. selector-option:: AMD Instinct MI355X (gfx950)
             :value: mi355x gfx=gfx950
@@ -39,6 +40,7 @@
       .. selector-dropdown:: Radeon GPU
          :key: gpu
          :show-cond: fam=radeon
+         :sort: desc
 
          .. selector-option:: AMD Radeon AI PRO R9700S (gfx1201)
             :value: ai-r9700s gfx=gfx1201
@@ -115,6 +117,7 @@
       .. selector-dropdown:: Ryzen APU
          :key: gpu
          :show-cond: fam=ryzen
+         :sort: desc
 
          .. selector-option:: AMD Ryzen AI Max+ PRO 495 (gfx1151)
             :value: max-plus-pro-495 gfx=gfx1151

--- a/docs/install/include/ror-gpu-selector.rst
+++ b/docs/install/include/ror-gpu-selector.rst
@@ -7,6 +7,7 @@
          .. selector-dropdown:: Radeon GPU
             :key: gpu
             :show-cond: fam=radeon
+            :sort: desc
 
             .. selector-option:: AMD Radeon AI PRO R9700S (gfx1201)
                :value: ai-r9700s gfx=gfx1201
@@ -83,6 +84,7 @@
          .. selector-dropdown:: Ryzen APU
             :key: gpu
             :show-cond: fam=ryzen
+            :sort: desc
 
             .. selector-option:: AMD Ryzen AI Max+ PRO 495 (gfx1151)
                :value: max-plus-pro-495 gfx=gfx1151


### PR DESCRIPTION
## Motivation

Previously, the list of GPUs in dropdowns was an unhelpful attempt at sorting by PRO/non-PRO SKUs and by newest first. It is more useful to sort alphabetically.

ISSUE ID: AIROCDOC-4123

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

(post-review edit)
Add `:sort:` option to the custom `selector-dropdown` rST directive. Allowed values are `asc` and `desc` to sort in ascending or descending alphabetical order based on the item's text label.

This lets maintainers organize entries in whatever way is convenient, but render them in an alphabetically sorted format.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Look at the preview: https://advanced-micro-devices-demo--6535.com.readthedocs.build/en/6535/install/rocm.html?fam=ryzen&w=compute&os=ubuntu&ubuntu-ver=26.04&i=pkgman&gpu=ai-5-pro-435&gfx=gfx1153

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Sorting is consistent and more sane

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
