### PR TITLE
docs(selector.js): Inline input field for visual clarity

### DIFF
--- a/docs/extension/rocm_docs_custom/selector/static/selector-toc2.js
+++ b/docs/extension/rocm_docs_custom/selector/static/selector-toc2.js
@@ -116,7 +116,6 @@ export function updateTOC2OptionsList() {
     liEl.appendChild(selectEl);
 
     const ts = new TomSelect(selectEl, {
-      plugins: ["dropdown_input"],
       onChange(value) {
         // For dropdown groups on the main page, drive via TomSelect so its
         // change event fires and selector.js handles the update. Calling

--- a/docs/extension/rocm_docs_custom/selector/static/selector.js
+++ b/docs/extension/rocm_docs_custom/selector/static/selector.js
@@ -601,7 +601,7 @@ domReady(() => {
     const key = elem.dataset.selectorKey;
     if (!key) return;
 
-    const ts = new TomSelect(elem, { plugins: ["dropdown_input"] });
+    const ts = new TomSelect(elem);
 
     const initVal = initialState[key];
     if (initVal !== undefined && ts.getValue() !== initVal) {


### PR DESCRIPTION
## Motivation

Previously, I had the input field (to search dropdown items) appear below the currently selected item. Based on feedback, this is not helpful and is visually confusing as the input overlaps with subsequent selectors.

ISSUE ID: AIROCDOC-4125

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Remove the `dropdown_input` plugin.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Look at the preview: https://advanced-micro-devices-demo--6538.com.readthedocs.build/en/6538/install/rocm.html?fam=ryzen&gpu=max-392&gfx=gfx1151&w=compute&os=windows&i=pip&windows-ver=11

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Input field is inline

<img width="1040" height="667" alt="image" src="https://github.com/user-attachments/assets/f1e29343-465c-46f9-b8a5-109256ec90db" />


<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
