### PR TITLE
Fix Ubuntu Docker build script and documentation paths

### DIFF
--- a/tools/rocm-build/docker/ubuntu22/Dockerfile
+++ b/tools/rocm-build/docker/ubuntu22/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:jammy as builder
+FROM ubuntu:jammy AS builder
 COPY packages /tmp/packages
 COPY local-pin-600 /tmp/local-pin-600
-COPY install-prerequisities.sh /tmp/install-prerequisities.sh
-RUN chmod +x /tmp/install-prerequisities.sh
+COPY install-prerequisites.sh /tmp/install-prerequisites.sh
+RUN chmod +x /tmp/install-prerequisites.sh
 ENV KBUILD_PKG_ROOTCMD=
 ENV RPP_DEPS_LOCATION=/usr/local/rpp-deps
-RUN  /tmp/install-prerequisities.sh
+RUN  /tmp/install-prerequisites.sh
 WORKDIR /src

--- a/tools/rocm-build/docker/ubuntu22/README.md
+++ b/tools/rocm-build/docker/ubuntu22/README.md
@@ -3,13 +3,13 @@
 1. Clone this repository.
 
    ```bash
-   git clone https://github.com/ROCm/rocm-build.git
+   git clone https://github.com/ROCm/ROCm.git
    ```
 
-2. Go into the OS-specific Docker directory in build-infra.
+2. Go into the Ubuntu 22.04 Docker directory.
 
     ```bash
-    cd rocm-build/build/docker/ubuntu22
+    cd ROCm/tools/rocm-build/docker/ubuntu22
     ```
 
 3. Build the Docker image

--- a/tools/rocm-build/docker/ubuntu24/Dockerfile
+++ b/tools/rocm-build/docker/ubuntu24/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:noble as builder	
+FROM ubuntu:noble AS builder
 COPY packages /tmp/packages
 COPY local-pin-600 /tmp/local-pin-600
-COPY install-prerequisities.sh /tmp/install-prerequisities.sh
-RUN chmod +x /tmp/install-prerequisities.sh
+COPY install-prerequisites.sh /tmp/install-prerequisites.sh
+RUN chmod +x /tmp/install-prerequisites.sh
 ENV KBUILD_PKG_ROOTCMD=
 ENV RPP_DEPS_LOCATION=/usr/local/rpp-deps
 ENV PATH="/opt/venv/bin:$PATH"
 ENV PATH=$PATH:"/usr/local/bin"
-RUN  /tmp/install-prerequisities.sh
+RUN  /tmp/install-prerequisites.sh
 WORKDIR /src

--- a/tools/rocm-build/docker/ubuntu24/README.md
+++ b/tools/rocm-build/docker/ubuntu24/README.md
@@ -3,13 +3,13 @@
 1. Clone this repository.
 
    ```bash
-   git clone https://github.com/ROCm/rocm-build.git
+   git clone https://github.com/ROCm/ROCm.git
    ```
 
-2. Go into the OS-specific Docker directory in build-infra.
+2. Go into the Ubuntu 24.04 Docker directory.
 
     ```bash
-    cd rocm-build/build/docker/ubuntu22
+    cd ROCm/tools/rocm-build/docker/ubuntu24
     ```
 
 3. Build the Docker image


### PR DESCRIPTION
## Summary

- reference the checked-in `install-prerequisites.sh` from both Ubuntu
  Dockerfiles
- update the READMEs to clone `ROCm/ROCm` and enter the matching Docker
  directory
- normalize `FROM ... AS ...` casing so Docker's build check is clean

Fixes #6542

## Testing

```text
$ docker build --check tools/rocm-build/docker/ubuntu22
Check complete, no warnings found.

$ docker build --check tools/rocm-build/docker/ubuntu24
Check complete, no warnings found.
```

The following static checks also completed successfully:

```bash
git diff --check
test -f tools/rocm-build/docker/ubuntu22/install-prerequisites.sh
test -f tools/rocm-build/docker/ubuntu24/install-prerequisites.sh
! rg -n 'install-prerequisities|rocm-build/build/docker' \
  tools/rocm-build/docker/ubuntu22 \
  tools/rocm-build/docker/ubuntu24
```

This PR runs Docker's check mode only; it does not perform the full
dependency-heavy ROCm builder image build.
