### PR TITLE
Remove full Git config dumps from profiler build logs

### DIFF
--- a/tools/rocm-build/build_omnitrace.sh
+++ b/tools/rocm-build/build_omnitrace.sh
@@ -144,7 +144,6 @@ build_omnitrace() {
     git submodule status
     echo "Cached (old) submodule status"
     git submodule status --cached
-    cat .git/config
 
     echo "Updating submodules"
     git submodule init
@@ -155,7 +154,6 @@ build_omnitrace() {
 
     echo "Updated submodule status"
     git submodule status
-    cat .git/config
 
     echo "Build directory: $BUILD_DIR"
     pushd "$BUILD_DIR" || exit

--- a/tools/rocm-build/build_rocprofiler-systems.sh
+++ b/tools/rocm-build/build_rocprofiler-systems.sh
@@ -143,7 +143,6 @@ build_rocprofiler_systems() {
     git submodule status
     echo "Cached (old) submodule status"
     git submodule status --cached
-    cat .git/config
 
     echo "Updating submodules"
     git submodule init
@@ -154,7 +153,6 @@ build_rocprofiler_systems() {
 
     echo "Updated submodule status"
     git submodule status
-    cat .git/config
 
     echo "Build directory: $BUILD_DIR"
     pushd "$BUILD_DIR" || exit


### PR DESCRIPTION
## Summary

- remove full `.git/config` output from the Omnitrace build helper
- remove full `.git/config` output from the rocprofiler-systems build helper
- retain the existing current and cached submodule status diagnostics

Fixes #6544

## Testing

```bash
bash -n tools/rocm-build/build_omnitrace.sh
bash -n tools/rocm-build/build_rocprofiler-systems.sh
! rg -n 'cat\s+\.git/config' \
  tools/rocm-build/build_omnitrace.sh \
  tools/rocm-build/build_rocprofiler-systems.sh
git diff --check
```

All commands completed with exit status 0.
