### PR TITLE
Write precision-support artifacts to an isolated output directory

### DIFF
--- a/.claude/commands/precision-check-delta.md
+++ b/.claude/commands/precision-check-delta.md
@@ -7,24 +7,26 @@ Only checks libraries where the source file itself changed between the two relea
 ## Step 1 — Fetch source files
 
 ```bash
-cd ~/projects/ROCm-internal/tools/autotag && python3 precision_fetch.py -t "$GITHUB_TOKEN" --previous PREVIOUS --current CURRENT --sha-filter
+cd ~/projects/ROCm-internal/tools/precision-support && python3 precision_fetch.py -t "$GITHUB_TOKEN" --previous PREVIOUS --current CURRENT --sha-filter
 ```
 
-Replace PREVIOUS and CURRENT from $ARGUMENTS.
+Replace PREVIOUS and CURRENT from $ARGUMENTS. Record the `Output directory:`
+path printed by the command as `OUTPUT_DIR`.
 
 ## Step 2 — Read library list
 
-Read `/tmp/precision_libs.txt`.
+Read `OUTPUT_DIR/precision_libs.txt`.
 
 ## Step 3 — Parse each library
 
 For each library in the list:
 
-- Source file exists (`/tmp/precision_{lib}_source.txt`): read it and `/tmp/precision_{lib}_yaml.txt`, then compare.
-- URL file exists (`/tmp/precision_{lib}_url.txt`): read it — this is the GitHub link to the source file, used in the detail block Source field.
-- Skip file exists (`/tmp/precision_{lib}_skip.txt`): note the reason.
+- Source file exists (`OUTPUT_DIR/precision_{lib}_source.txt`): read it and `OUTPUT_DIR/precision_{lib}_yaml.txt`, then compare.
+- URL file exists (`OUTPUT_DIR/precision_{lib}_url.txt`): read it — this is the GitHub link to the source file, used in the detail block Source field.
+- Skip file exists (`OUTPUT_DIR/precision_{lib}_skip.txt`): note the reason.
 
-**Do not use GitHub MCP tools, WebFetch, or any network call.** All content is already in `/tmp/`. Use only the Read tool on those files.
+**Do not use GitHub MCP tools, WebFetch, or any network call.** All content is
+already in `OUTPUT_DIR`. Use only the Read tool on those files.
 
 You are the parser. Read the source file directly — do not infer from filenames or prior knowledge.
 
@@ -61,7 +63,7 @@ For each finding, decide **auto-update** or **flag**:
 
 For auto-update findings, add the missing types to `~/projects/ROCm-internal/docs/data/reference/precision-support/precision-support.yaml`. Match the existing format exactly (type + support fields).
 
-Then write a log to `~/projects/ROCm-internal/tools/autotag/precision-update-log/PREVIOUS-CURRENT-YYYYMMDD-HHMMSS.md` (replace PREVIOUS/CURRENT from $ARGUMENTS, timestamp from `date +%Y%m%d-%H%M%S`). Always create a new file — never read or overwrite an existing log. Log format:
+Then write a log to `~/projects/ROCm-internal/tools/precision-support/precision-update-log/PREVIOUS-CURRENT-YYYYMMDD-HHMMSS.md` (replace PREVIOUS/CURRENT from $ARGUMENTS, timestamp from `date +%Y%m%d-%H%M%S`). Always create a new file — never read or overwrite an existing log. Log format:
 
 ```markdown
 # Precision support audit: ROCm PREVIOUS → CURRENT
@@ -88,7 +90,7 @@ Then the summary table. **This MUST be a markdown table — no lists, no separat
 |---------|---------|--------|--------|
 | ... | ... | ... | filename.ext |
 
-Use the URL from `/tmp/precision_{lib}_url.txt`. In the Source column, write only the filename (last path segment, plain text — no markdown link). For skipped libraries, leave Source blank.
+Use the URL from `OUTPUT_DIR/precision_{lib}_url.txt`. In the Source column, write only the filename (last path segment, plain text — no markdown link). For skipped libraries, leave Source blank.
 
 Then, **for flagged libraries only**, a detail block:
 
@@ -98,7 +100,7 @@ Then, **for flagged libraries only**, a detail block:
 
 - Finding: ...
 - Details: ...
-- Source: [filename](url) — full clickable link using the URL from `/tmp/precision_{lib}_url.txt`.
+- Source: [filename](url) — full clickable link using the URL from `OUTPUT_DIR/precision_{lib}_url.txt`.
 - Recommended action: ...
 
 Clean and skipped libraries appear only in the table — no detail block.

--- a/.claude/commands/precision-check.md
+++ b/.claude/commands/precision-check.md
@@ -8,21 +8,23 @@ Precision support delta check. Arguments: $ARGUMENTS = "previous_version current
 cd ~/projects/ROCm-internal/tools/precision-support && python3 precision_fetch.py -t "$GITHUB_TOKEN" --previous PREVIOUS --current CURRENT
 ```
 
-Replace PREVIOUS and CURRENT from $ARGUMENTS.
+Replace PREVIOUS and CURRENT from $ARGUMENTS. Record the `Output directory:`
+path printed by the command as `OUTPUT_DIR`.
 
 ## Step 2 — Read library list
 
-Read `/tmp/precision_libs.txt`.
+Read `OUTPUT_DIR/precision_libs.txt`.
 
 ## Step 3 — Parse each library
 
 For each library in the list:
 
-- Source file exists (`/tmp/precision_{lib}_source.txt`): read it and `/tmp/precision_{lib}_yaml.txt`, then compare.
-- URL file exists (`/tmp/precision_{lib}_url.txt`): read it — this is the GitHub link to the source file, used in the detail block Source field.
-- Skip file exists (`/tmp/precision_{lib}_skip.txt`): note the reason.
+- Source file exists (`OUTPUT_DIR/precision_{lib}_source.txt`): read it and `OUTPUT_DIR/precision_{lib}_yaml.txt`, then compare.
+- URL file exists (`OUTPUT_DIR/precision_{lib}_url.txt`): read it — this is the GitHub link to the source file, used in the detail block Source field.
+- Skip file exists (`OUTPUT_DIR/precision_{lib}_skip.txt`): note the reason.
 
-**Do not use GitHub MCP tools, WebFetch, or any network call.** All content is already in `/tmp/`. Use only the Read tool on those files.
+**Do not use GitHub MCP tools, WebFetch, or any network call.** All content is
+already in `OUTPUT_DIR`. Use only the Read tool on those files.
 
 You are the parser. Read the source file directly — do not infer from filenames or prior knowledge.
 
@@ -86,7 +88,7 @@ Then the summary table. **This MUST be a markdown table — no lists, no separat
 |---------|---------|--------|--------|
 | ... | ... | ... | filename.ext |
 
-Use the URL from `/tmp/precision_{lib}_url.txt`. In the Source column, write only the filename (last path segment, plain text — no markdown link). For skipped libraries, leave Source blank.
+Use the URL from `OUTPUT_DIR/precision_{lib}_url.txt`. In the Source column, write only the filename (last path segment, plain text — no markdown link). For skipped libraries, leave Source blank.
 
 Then, **for flagged libraries only**, a detail block:
 
@@ -96,7 +98,7 @@ Then, **for flagged libraries only**, a detail block:
 
 - Finding: ...
 - Details: ...
-- Source: [filename](url) — full clickable link using the URL from `/tmp/precision_{lib}_url.txt`.
+- Source: [filename](url) — full clickable link using the URL from `OUTPUT_DIR/precision_{lib}_url.txt`.
 - Recommended action: ...
 
 Clean and skipped libraries appear only in the table — no detail block.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,11 +1,10 @@
 {
   "permissions": {
     "allow": [
-      "Bash(cd ~/projects/ROCm-internal/tools/autotag && python3 precision_fetch.py*)",
-      "Read(/tmp/precision_*)",
+      "Bash(cd ~/projects/ROCm-internal/tools/precision-support && python3 precision_fetch.py*)",
+      "Read(//tmp/rocm-precision-*/**)",
       "Edit(docs/data/reference/precision-support/precision-support.yaml)",
-      "Write(tools/autotag/precision-update-log/*)",
-      "Write(precision-update-log/*)",
+      "Write(tools/precision-support/precision-update-log/*)",
       "Bash(date +%Y%m%d-%H%M%S)"
     ]
   }

--- a/tools/precision-support/README.md
+++ b/tools/precision-support/README.md
@@ -46,8 +46,9 @@ python3 tag_script.py -t $GITHUB_ACCESS_TOKEN --no-release --no-pulls --compile_
 
 Audits data-type support across ROCm libraries between two releases. Uses a hybrid
 approach: `precision_fetch.py` fetches raw source files and YAML snapshots from
-GitHub to `/tmp/`, then Claude reads and compares them semantically via a slash
-command — no regex parsers.
+GitHub to a private, per-run directory under the system temporary directory,
+then Claude reads and compares them semantically via a slash command — no regex
+parsers. The fetcher prints the generated output directory at the end of each run.
 
 ### Commands
 
@@ -80,13 +81,18 @@ Open Claude Code in this repo and run:
 
 Claude will:
 
-1. Run `precision_fetch.py` to download source files and YAML snapshots to `/tmp/`.
+1. Run `precision_fetch.py` to download source files and YAML snapshots to an isolated output directory.
 2. Read and compare each library's source against `precision-support.yaml`.
 3. Auto-update the YAML for clear missing entries.
 4. Flag ambiguous findings (macro expansion, combination tables, support level mismatches) for human review.
-5. Write a timestamped log to `tools/autotag/precision-update-log/` (gitignored — local only).
+5. Write a timestamped log to `tools/precision-support/precision-update-log/` (gitignored — local only).
 
 Commit any YAML changes. The YAML being audited lives at `docs/data/reference/precision-support/precision-support.yaml`.
+
+To keep artifacts in a specific directory for automation or debugging, invoke the
+fetcher directly with `--output-dir PATH`. When this option is omitted, each run
+uses a newly created directory with a name such as
+`/tmp/rocm-precision-abc123`.
 
 ### Adding new libraries to precision support
 

--- a/tools/precision-support/precision_fetch.py
+++ b/tools/precision-support/precision_fetch.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Fetch precision support source files and YAML for Claude to compare.
 
-Writes raw content to /tmp/ for the Claude precision-check command.
-Claude reads the files and does the comparison — no regex parsers used.
+Writes raw content to an isolated output directory for the Claude
+precision-check command. Claude reads the files and does the comparison — no
+regex parsers used.
 
 Usage (manifest-scoped — full audit):
     python3 precision_fetch.py -t $GITHUB_TOKEN --previous 7.1.1 --current 7.2.0
@@ -17,7 +18,9 @@ Usage (explicit library list):
 import argparse
 import base64
 import json
+import re
 import sys
+import tempfile
 from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
@@ -28,6 +31,37 @@ except ImportError:
     sys.exit("pyyaml is required: pip install pyyaml")
 
 from manifest_diff import fetch_manifest, diff_manifests
+
+
+# ---------------------------------------------------------------------------
+# Output files
+# ---------------------------------------------------------------------------
+
+_ARTIFACT_COMPONENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+def prepare_output_dir(requested: Path | None) -> Path:
+    """Create and return the directory used for this run's artifacts."""
+    if requested is None:
+        return Path(tempfile.mkdtemp(prefix="rocm-precision-"))
+
+    output_dir = requested.expanduser().resolve()
+    try:
+        output_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    except OSError as error:
+        raise SystemExit(f"Cannot create output directory {output_dir}: {error}") from error
+
+    if not output_dir.is_dir():
+        raise SystemExit(f"Output path is not a directory: {output_dir}")
+    return output_dir
+
+
+def artifact_path(output_dir: Path, library: str, kind: str) -> Path:
+    """Return a confined artifact path for a library and artifact kind."""
+    for label, value in (("library", library), ("artifact kind", kind)):
+        if not _ARTIFACT_COMPONENT.fullmatch(value):
+            raise ValueError(f"Invalid {label}: {value!r}")
+    return output_dir / f"precision_{library}_{kind}.txt"
 
 
 # ---------------------------------------------------------------------------
@@ -307,7 +341,12 @@ def load_yaml_types(yaml_data: dict) -> dict[str, dict[str, str]]:
 # Scoping
 # ---------------------------------------------------------------------------
 
-def sha_filter_scope(token: str, previous: str, current: str) -> list[str]:
+def sha_filter_scope(
+    token: str,
+    previous: str,
+    current: str,
+    output_dir: Path,
+) -> list[str]:
     """Return sorted list of library tags where the source file changed between two ROCm versions.
 
     Checks all tracked libraries — no manifest diff. Skips libraries where the
@@ -322,13 +361,13 @@ def sha_filter_scope(token: str, previous: str, current: str) -> list[str]:
         sha_prev = fetch_file_sha(token, org, repo, path, previous)
         sha_curr = fetch_file_sha(token, org, repo, path, current)
         if sha_prev is None and sha_curr is None:
-            Path(f"/tmp/precision_{lib}_skip.txt").write_text(
+            artifact_path(output_dir, lib, "skip").write_text(
                 f"Source file not found at either {previous} or {current}",
                 encoding="utf-8",
             )
             print(f"  {lib}: not found at either version — skip", file=sys.stderr)
         elif sha_prev == sha_curr:
-            Path(f"/tmp/precision_{lib}_skip.txt").write_text(
+            artifact_path(output_dir, lib, "skip").write_text(
                 f"Source file unchanged between {previous} and {current} (SHA match)",
                 encoding="utf-8",
             )
@@ -371,8 +410,8 @@ def scope_from_manifest(token: str, previous: str, current: str) -> list[str]:
 # Fetching
 # ---------------------------------------------------------------------------
 
-def fetch_library(token: str, lib: str, version: str) -> None:
-    """Fetch source file and YAML entry for one library, write to /tmp/."""
+def fetch_library(token: str, lib: str, version: str, output_dir: Path) -> None:
+    """Fetch source file and YAML entry for one library."""
     config = SOURCE_CONFIG.get(lib)
     if not config:
         print(f"  {lib}: no SOURCE_CONFIG entry — skipping", file=sys.stderr)
@@ -380,7 +419,7 @@ def fetch_library(token: str, lib: str, version: str) -> None:
 
     note = config.get("note")
     if note:
-        Path(f"/tmp/precision_{lib}_skip.txt").write_text(note, encoding="utf-8")
+        artifact_path(output_dir, lib, "skip").write_text(note, encoding="utf-8")
         print(f"  {lib}: skipped — {note}", file=sys.stderr)
         return
 
@@ -393,17 +432,17 @@ def fetch_library(token: str, lib: str, version: str) -> None:
     )
 
     if content is None:
-        Path(f"/tmp/precision_{lib}_skip.txt").write_text(
+        artifact_path(output_dir, lib, "skip").write_text(
             f"Source file not found: {config['path']}", encoding="utf-8"
         )
         print(f"  {lib}: source file not found", file=sys.stderr)
         return
 
-    Path(f"/tmp/precision_{lib}_source.txt").write_text(content, encoding="utf-8")
+    artifact_path(output_dir, lib, "source").write_text(content, encoding="utf-8")
 
     ref = _version_to_ref(version)
     gh_url = f"https://github.com/{config['org']}/{config['repo']}/blob/{ref}/{config['path']}"
-    Path(f"/tmp/precision_{lib}_url.txt").write_text(gh_url, encoding="utf-8")
+    artifact_path(output_dir, lib, "url").write_text(gh_url, encoding="utf-8")
 
     print(f"  {lib}: source written ({len(content):,} chars)", file=sys.stderr)
 
@@ -430,7 +469,14 @@ def main() -> None:
         help="Check all tracked libraries; skip those whose source file SHA is unchanged. "
              "Use with --previous/--current. No manifest diff is performed.",
     )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory for generated artifacts. "
+             "Defaults to a new private directory under the system temporary directory.",
+    )
     args = parser.parse_args()
+    output_dir = prepare_output_dir(args.output_dir)
 
     # Resolve version and library list
     if args.previous:
@@ -438,7 +484,12 @@ def main() -> None:
             sys.exit("--current is required when using --previous")
         current_version = args.current
         if args.sha_filter:
-            libs = sha_filter_scope(args.token, args.previous, args.current)
+            libs = sha_filter_scope(
+                args.token,
+                args.previous,
+                args.current,
+                output_dir,
+            )
         else:
             libs = scope_from_manifest(args.token, args.previous, args.current)
     else:
@@ -457,23 +508,23 @@ def main() -> None:
     # Write YAML entries for all tracked libraries (not just changed ones —
     # Claude needs the full context for comparison)
     for lib, types in yaml_types.items():
-        Path(f"/tmp/precision_{lib}_yaml.txt").write_text(
+        artifact_path(output_dir, lib, "yaml").write_text(
             yaml.dump({lib: types}, allow_unicode=True, default_flow_style=False),
             encoding="utf-8",
         )
 
     # Write manifest-scoped library list so Claude knows what to check
-    libs_file = Path("/tmp/precision_libs.txt")
+    libs_file = output_dir / "precision_libs.txt"
     libs_file.write_text("\n".join(libs), encoding="utf-8")
     print(f"\nLibraries to check: {', '.join(libs)}", file=sys.stderr)
 
     # Fetch source files
     print("\nFetching source files...", file=sys.stderr)
     for lib in libs:
-        fetch_library(args.token, lib, current_version)
+        fetch_library(args.token, lib, current_version, output_dir)
 
-    print(f"\nDone. Files written to /tmp/precision_*", file=sys.stderr)
-    print(f"Library list: /tmp/precision_libs.txt", file=sys.stderr)
+    print(f"\nOutput directory: {output_dir}", file=sys.stderr)
+    print(f"Library list: {libs_file}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/tools/precision-support/test_precision_fetch.py
+++ b/tools/precision-support/test_precision_fetch.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Unit tests for precision_fetch output handling."""
+
+import contextlib
+import io
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import precision_fetch
+
+
+class OutputDirectoryTests(unittest.TestCase):
+    def test_default_output_directories_are_private_and_unique(self) -> None:
+        real_mkdtemp = tempfile.mkdtemp
+        with tempfile.TemporaryDirectory() as parent:
+            with mock.patch.object(
+                precision_fetch.tempfile,
+                "mkdtemp",
+                side_effect=lambda prefix: real_mkdtemp(prefix=prefix, dir=parent),
+            ):
+                first = precision_fetch.prepare_output_dir(None)
+                second = precision_fetch.prepare_output_dir(None)
+
+            self.assertNotEqual(first, second)
+            self.assertTrue(first.name.startswith("rocm-precision-"))
+            self.assertEqual(stat.S_IMODE(first.stat().st_mode), 0o700)
+            self.assertEqual(stat.S_IMODE(second.stat().st_mode), 0o700)
+
+    def test_requested_output_directory_is_created(self) -> None:
+        with tempfile.TemporaryDirectory() as parent:
+            requested = Path(parent) / "nested" / "artifacts"
+            result = precision_fetch.prepare_output_dir(requested)
+
+            self.assertEqual(result, requested.resolve())
+            self.assertTrue(result.is_dir())
+
+    def test_artifact_path_rejects_unsafe_components(self) -> None:
+        output_dir = Path("/tmp/example")
+
+        with self.assertRaises(ValueError):
+            precision_fetch.artifact_path(output_dir, "../../escape", "source")
+        with self.assertRaises(ValueError):
+            precision_fetch.artifact_path(output_dir, "hipblas", "../source")
+
+
+class ArtifactWritingTests(unittest.TestCase):
+    def test_sha_filter_writes_skip_file_to_output_directory(self) -> None:
+        config = {
+            "hipblas": {
+                "org": "ROCm",
+                "repo": "rocm-libraries",
+                "path": "precision.rst",
+            }
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            output_dir = Path(directory)
+            with (
+                mock.patch.dict(precision_fetch.SOURCE_CONFIG, config, clear=True),
+                mock.patch.object(
+                    precision_fetch,
+                    "fetch_file_sha",
+                    side_effect=["same-sha", "same-sha"],
+                ),
+            ):
+                changed = precision_fetch.sha_filter_scope(
+                    "token",
+                    "7.1.1",
+                    "7.2.0",
+                    output_dir,
+                )
+
+            self.assertEqual(changed, [])
+            skip_file = output_dir / "precision_hipblas_skip.txt"
+            self.assertIn("unchanged", skip_file.read_text(encoding="utf-8"))
+
+    def test_fetch_library_writes_source_and_url_to_output_directory(self) -> None:
+        config = {
+            "testlib": {
+                "org": "ROCm",
+                "repo": "example",
+                "path": "docs/precision.rst",
+            }
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            output_dir = Path(directory)
+            with (
+                mock.patch.dict(precision_fetch.SOURCE_CONFIG, config, clear=True),
+                mock.patch.object(
+                    precision_fetch,
+                    "fetch_source_file",
+                    return_value="source content",
+                ),
+            ):
+                precision_fetch.fetch_library(
+                    "token",
+                    "testlib",
+                    "7.2.0",
+                    output_dir,
+                )
+
+            self.assertEqual(
+                (output_dir / "precision_testlib_source.txt").read_text(
+                    encoding="utf-8"
+                ),
+                "source content",
+            )
+            self.assertIn(
+                "release/rocm-rel-7.2/docs/precision.rst",
+                (output_dir / "precision_testlib_url.txt").read_text(encoding="utf-8"),
+            )
+
+    def test_main_writes_all_artifacts_to_requested_directory(self) -> None:
+        yaml_data = {
+            "library_groups": [
+                {
+                    "libraries": [
+                        {
+                            "tag": "hipblas",
+                            "data_types": [{"type": "float32", "support": "supported"}],
+                        }
+                    ]
+                }
+            ]
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            output_dir = Path(directory) / "artifacts"
+            argv = [
+                "precision_fetch.py",
+                "--token",
+                "test-token",
+                "--version",
+                "7.2.0",
+                "--libs",
+                "hipblas",
+                "--output-dir",
+                os.fspath(output_dir),
+            ]
+            stderr = io.StringIO()
+            with (
+                mock.patch.object(sys, "argv", argv),
+                mock.patch.object(
+                    precision_fetch, "fetch_yaml", return_value=yaml_data
+                ),
+                mock.patch.object(
+                    precision_fetch,
+                    "fetch_source_file",
+                    return_value="source content",
+                ),
+                contextlib.redirect_stderr(stderr),
+            ):
+                precision_fetch.main()
+
+            self.assertEqual(
+                sorted(path.name for path in output_dir.iterdir()),
+                [
+                    "precision_hipblas_source.txt",
+                    "precision_hipblas_url.txt",
+                    "precision_hipblas_yaml.txt",
+                    "precision_libs.txt",
+                ],
+            )
+            self.assertEqual(
+                (output_dir / "precision_libs.txt").read_text(encoding="utf-8"),
+                "hipblas",
+            )
+            self.assertIn(
+                f"Output directory: {output_dir.resolve()}",
+                stderr.getvalue(),
+            )
+            self.assertNotIn("test-token", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- create a unique owner-only output directory for each precision audit
- add `--output-dir` for explicit automation and debugging paths
- validate artifact-name components before constructing output paths
- update `/precision-check`, `/precision-check-delta`, project permissions, and
  the precision-support README to consume the printed directory
- correct the delta command and log paths to the checked-in
  `tools/precision-support` location
- add mock-based output and confinement tests

Fixes #6546

## Compatibility

The default changes from shared `/tmp/precision_*` files to a unique directory
printed as `Output directory: ...`. Callers that require a stable path can pass
`--output-dir PATH`.

## Testing

```text
$ python3.12 -m unittest tools/precision-support/test_precision_fetch.py
Ran 6 tests in 0.006s
OK

$ ruff check tools/precision-support/precision_fetch.py \
    tools/precision-support/test_precision_fetch.py
All checks passed!
```

Additional successful checks:

```bash
python3.12 -m py_compile \
  tools/precision-support/precision_fetch.py \
  tools/precision-support/test_precision_fetch.py
python3.12 -m json.tool .claude/settings.json >/dev/null
! rg -n '/tmp/precision_|tools/autotag.*precision_fetch|tools/autotag/precision-update-log' \
  .claude tools/precision-support
git diff --check
```

All network-facing functions are mocked in the tests; no real GitHub token or
network request is used.
