### PR TITLE
fix(selector.js): dropdown open/close flicker on click after browser window is refocused

### DIFF
--- a/docs/extension/rocm_docs_custom/selector/static/selector.js
+++ b/docs/extension/rocm_docs_custom/selector/static/selector.js
@@ -619,6 +619,16 @@ domReady(() => {
     });
   });
 
+  // When the browser window loses focus, "blur" any focused TomSelect control.
+  // Prevents dropdown flicker when the window is refocused.
+  window.addEventListener("blur", () => {
+    for (const instances of dropdownInstances.values()) {
+      for (const ts of instances) {
+        ts.blur();
+      }
+    }
+  });
+
   for (const [key, value] of Object.entries(initialState)) {
     applySelectionByKey(key, value);
   }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

ISSUE ID: AIROCDOC-4124

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

When the browser window loses focus, "blur" any focused TomSelect control.

This prevents the browser from automatically restoring focus to the dropdown on window
refocus, which would trigger openOnFocus and cause the dropdown to
flicker open unexpectedly due to registering the first click as a close.

Note: "blur" just means the opposite of focus in browser lingo... not a visual blur. https://developer.mozilla.org/en-US/docs/Web/API/Window/blur_event

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
