### PR TITLE
[docs/7.14.0] rm inaccurate release label in TheRock transition guide

### DIFF
--- a/docs/about/transition-guide-TheRock.md
+++ b/docs/about/transition-guide-TheRock.md
@@ -1,6 +1,6 @@
 # Transition guide from legacy ROCm release stream
 
-[ROCm Core SDK 7.14.0](https://rocm.docs.amd.com/en/latest/index.html#rocm-core-sdk) marks a step change from the ROCm legacy release stream. It is a preview release built on our new build system, TheRock.
+[ROCm Core SDK 7.14.0](https://rocm.docs.amd.com/en/latest/index.html#rocm-core-sdk) marks a step change from the ROCm legacy release stream. It is built on our new build system, TheRock.
 
 ## Major changes
 


### PR DESCRIPTION
## Motivation

The TheRock transition guide intro described ROCm Core SDK 7.14.0 as a "preview release," which is inaccurate. This drops the release label so the intro just states that the Core SDK is built on TheRock.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.